### PR TITLE
refactor: rename --generate-params-types option to --params-file with…

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -11,7 +11,7 @@ import { generatePages } from "./generate-path-structure";
 
 interface Options {
   watch?: boolean;
-  generateParamsTypes?: string | boolean;
+  paramsFile?: string | boolean;
 }
 
 const program = new Command();
@@ -27,7 +27,7 @@ program
   .argument("<outputPath>", "Output path for the generated type definitions")
   .option("-w, --watch", "Watch mode: regenerate on file changes")
   .option(
-    "--generate-params-types [filename]",
+    "-p, --params-file [filename]",
     "Generate params types file with specified filename"
   )
   .action((baseDir: string, outputPath: string, options: Options) => {
@@ -35,11 +35,9 @@ program
     const resolvedOutputPath = path.resolve(outputPath).replace(/\\/g, "/");
 
     const paramsFileName =
-      typeof options.generateParamsTypes === "string"
-        ? options.generateParamsTypes
-        : null;
+      typeof options.paramsFile === "string" ? options.paramsFile : null;
 
-    if (options.generateParamsTypes !== undefined && !paramsFileName) {
+    if (options.paramsFile !== undefined && !paramsFileName) {
       console.error(
         chalk.red(
           "Error: --generate-params-types requires a filename (e.g., params.ts) when specified."


### PR DESCRIPTION
# Pull Request

## 📝 Overview

- Renamed `--generate-params-types` option to `--params-file`
- Added shorthand option `-p`

## 😨 Motivation and Background

- The old option name was too verbose and unclear.
- `--params-file` better describes the purpose, and `-p` is convenient for CLI users.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [x] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- Users now can use:
    ```
    --params-file <file>
    -p <file>
    ```

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed

