### PR TITLE
feat: automate changelog generation and GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,22 @@ jobs:
           git commit -m "chore: bump version to v${{ steps.extract_version.outputs.version }}" || echo "No changes to commit"
           git push origin HEAD:refs/heads/${{ steps.default_branch.outputs.branch }}
 
+      - name: Generate changelog
+        id: changelog
+        run: |
+          echo "changelog<<EOF" >> "$GITHUB_OUTPUT"
+          git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:"- %s" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.extract_version.outputs.version }}
+          name: Release v${{ steps.extract_version.outputs.version }}
+          body: ${{ steps.changelog.outputs.changelog }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish to npm
         run: npm publish
         env:


### PR DESCRIPTION
## 📝 Overview

- Automate changelog generation and GitHub release creation during the release workflow.

## 🧐 Motivation and Background

- Previously, changelog generation and GitHub release creation were manual tasks.
- Automating these steps reduces human error and saves time during the release process.

## ✅ Changes

- [x] Feature added: Generate changelog automatically using git log.
- [x] Feature added: Create GitHub Release automatically using softprops/action-gh-release.

## 💡 Notes / Screenshots

- The changelog includes commit messages since the last tag.
- The GitHub release will now automatically be created after bumping the version.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed with a successful release and changelog generation