### PR TITLE
docs: update option descriptions for watch and params-file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ npx rpc4next <baseDir> <outputPath>
 #### オプション
 
 - **ウォッチモード**  
-  ファイル変更を検知して自動的に再生成する場合は `--watch` オプションを付けます。
+  ファイル変更を検知して自動的に再生成する場合は `--watch` or `-w` オプションを付けます。
 
   ```bash
   npx rpc4next <baseDir> <outputPath> --watch
   ```
 
 - **パラメータ型ファイルの生成**  
-  各ルートに対して個別のパラメータ型定義ファイルを生成する場合は、`--generate-params-types` オプションにファイル名を指定します。
+  各ルートに対して個別のパラメータ型定義ファイルを生成する場合は、`--params-file` or `-p` オプションにファイル名を指定します。
 
   ```bash
   npx rpc4next <baseDir> <outputPath> --generate-params-types <paramsFileName>


### PR DESCRIPTION
## 📝 Overview

- Updated the README to clarify option descriptions.
- `--watch` now mentions the short option `-w`.
- `--generate-params-types` option is now renamed to `--params-file` with short option `-p`.

## 😮 Motivation and Background

- Improve usability and consistency by aligning CLI options with common naming conventions.
- Help users quickly understand available options with short aliases.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [x] Documentation updated

## 💡 Notes / Screenshots

- Not applicable

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed

