### PR TITLE
feat: optimize route scanning with scanAppDirCache, refactor cache logic, and improve tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Inspired by Hono RPC and Pathpida, **rpc4next** automatically generates a type-s
 ## ✨ Features
 
 - ✅ 既存の `app/**/route.ts` および `app/**/page.tsx` を活用するため、新たなハンドラファイルの作成は不要
-- ✅ ルート、パラメータ、リクエストボディ、レスポンスの型安全なクライアント生成
+- ✅ ルート、パラメータ、クエリパラメータ、 リクエストボディ、レスポンスの型安全なクライアント生成
 - ✅ 最小限のセットアップで、カスタムサーバー不要
 - ✅ 動的ルート（`[id]`、`[...slug]` など）に対応
 - ✅ CLI による自動クライアント用型定義生成
@@ -30,19 +30,29 @@ npm install rpc4next
 ### 2. Define API Routes in Next.js
 
 Next.js プロジェクト内の既存の `app/**/route.ts` と `app/**/page.tsx` ファイルをそのまま利用できます。
+さらに、クエリパラメータ（searchParams）の型安全性を有効にするには、対象のファイル内で `Query` または `OptionalQuery` 型を定義し、`export` してください。
 
 ```ts
 // app/api/user/[id]/route.ts
 import { NextRequest, NextResponse } from "next/server";
+
+// searchParams用の型定義
+export type Query = {
+  q: string; // 必須
+  page?: number; // 任意
+};
 
 export async function GET(
   req: NextRequest,
   segmentData: { params: Promise<{ id: string }> }
 ) {
   const { id } = await segmentData.params;
-  return NextResponse.json({ name: `User ${id}` });
+  const q = req.nextUrl.searchParams.get("q");
+  return NextResponse.json({ id, q });
 }
 ```
+
+🚩 Query or OptionalQuery 型を export することで、searchParams の型も自動的にクライアントに反映されます。
 
 - **RPCとしてresponseの戻り値の推論が機能するのは、対象となる `route.ts` の HTTPメソッドハンドラ内で`NextResponse.json()` をしている物のみになります**
 
@@ -102,14 +112,16 @@ export const rpc = createClient<PathStructure>();
 import { rpc } from "@/lib/rpcClient";
 
 export default async function Page() {
-  const res = await rpc.api.user._id("123").$get();
+  const res = await rpc.api.user._id("123").$get({
+    query: { q: "hello", page: 1 },
+  });
   const json = await res.json();
-  return <div>{json.name}</div>;
+  return <div>{json.q}</div>;
 }
 ```
 
 - エディタの補完機能により、利用可能なエンドポイントが自動的に表示されます。
-- リクエストの構造（params, searchParams）はサーバーコードから推論され、レスポンスも型安全に扱えます。
+- リクエストの構造（params, query）はサーバーコードから推論され、レスポンスも型安全に扱えます。
 
 ---
 
@@ -126,7 +138,7 @@ export default async function Page() {
 
 2. **クライアント側補完強化**
 
-   - `status`, `content-type`, `json()`, `text()` などがステータスに応じて適切に補完される
+   - `status`, `content-type`, `json()`, `text()` などが適切に補完される
 
 3. **サーバー側 params / query も型安全**
    - `routeHandlerFactory()` を使えば、`params`, `query` も型推論可能

--- a/src/cli/core/alias.test.ts
+++ b/src/cli/core/alias.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { createImportAlias } from "./alias";
+
+describe("createImportAlias", () => {
+  it("should generate a consistent alias for the same input", () => {
+    const path = "src/utils";
+    const name = "myModule";
+    const alias1 = createImportAlias(path, name);
+    const alias2 = createImportAlias(path, name);
+    expect(alias1).toBe(alias2);
+  });
+
+  it("should generate different aliases for different paths", () => {
+    const name = "myModule";
+    const alias1 = createImportAlias("src/utils", name);
+    const alias2 = createImportAlias("src/components", name);
+    expect(alias1).not.toBe(alias2);
+  });
+
+  it("should generate different aliases for different names", () => {
+    const path = "src/utils";
+    const alias1 = createImportAlias(path, "myModule");
+    const alias2 = createImportAlias(path, "yourModule");
+    expect(alias1).not.toBe(alias2);
+  });
+
+  it("should include the original name as prefix", () => {
+    const path = "some/path";
+    const name = "aliasName";
+    const alias = createImportAlias(path, name);
+    expect(alias.startsWith(`${name}_`)).toBe(true);
+  });
+
+  it("should generate a hash with 16 characters", () => {
+    const alias = createImportAlias("any/path", "mod");
+    const hashPart = alias.split("_")[1];
+    expect(hashPart.length).toBe(16);
+    // Optional: check that it's a hex string
+    expect(hashPart).toMatch(/^[a-f0-9]{16}$/);
+  });
+});

--- a/src/cli/core/alias.ts
+++ b/src/cli/core/alias.ts
@@ -1,0 +1,11 @@
+import crypto from "crypto";
+
+export const createImportAlias = (path: string, name: string) => {
+  const hash = crypto
+    .createHash("md5")
+    .update(`${path}::${name}`)
+    .digest("hex")
+    .slice(0, 16);
+
+  return `${name}_${hash}`;
+};

--- a/src/cli/core/cache.test.ts
+++ b/src/cli/core/cache.test.ts
@@ -1,10 +1,8 @@
 import path from "path";
 import { describe, it, expect, beforeEach } from "vitest";
 import {
-  clearCntCache,
   clearVisitedDirsCacheAbove,
   clearScanAppDirCacheAbove,
-  cntCache,
   visitedDirsCache,
   scanAppDirCache,
 } from "./cache";
@@ -84,27 +82,6 @@ describe("clearVisitedDirsCacheAbove", () => {
     const originalSize = visitedDirsCache.size;
     clearVisitedDirsCacheAbove(filePath);
     expect(visitedDirsCache.size).toBe(originalSize);
-  });
-});
-
-describe("clearCntCache", () => {
-  beforeEach(() => {
-    clearCntCache();
-  });
-
-  it("clears populated cntCache", () => {
-    cntCache["key1"] = 10;
-    cntCache["key2"] = 20;
-
-    expect(Object.keys(cntCache)).toHaveLength(2);
-    clearCntCache();
-    expect(Object.keys(cntCache)).toHaveLength(0);
-  });
-
-  it("works even if cntCache is already empty", () => {
-    expect(Object.keys(cntCache)).toHaveLength(0);
-    clearCntCache();
-    expect(Object.keys(cntCache)).toHaveLength(0);
   });
 });
 

--- a/src/cli/core/cache.test.ts
+++ b/src/cli/core/cache.test.ts
@@ -3,31 +3,26 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   clearCntCache,
   clearVisitedDirsCacheAbove,
+  clearScanAppDirCacheAbove,
   cntCache,
   visitedDirsCache,
+  scanAppDirCache,
 } from "./cache";
 
-describe("clearVisitedDirsCacheAbove - when given a directory path", () => {
+describe("clearVisitedDirsCacheAbove", () => {
   beforeEach(() => {
-    // Reset cache before each test
     visitedDirsCache.clear();
 
-    // Example: set up cache entries
-    // Ancestors (above the target directory)
+    // Setup example entries
     visitedDirsCache.set("/project", true);
     visitedDirsCache.set("/project/src", true);
     visitedDirsCache.set("/project/src/app", true);
-    // Target directory and its descendants
     visitedDirsCache.set("/project/src/app/foo", true);
     visitedDirsCache.set("/project/src/app/foo/bar", true);
-    // Unrelated entry (should not be affected)
     visitedDirsCache.set("/project/other", true);
   });
 
-  it("should remove the target directory and all its ancestor directories", () => {
-    // Target: /project/src/app/foo
-    // Expect: /project, /project/src, /project/src/app, and /project/src/app/foo to be removed
-    //         /project/src/app/foo/bar should remain
+  it("removes target directory and its ancestors", () => {
     clearVisitedDirsCacheAbove("/project/src/app/foo");
 
     expect(visitedDirsCache.has("/project")).toBe(false);
@@ -35,13 +30,11 @@ describe("clearVisitedDirsCacheAbove - when given a directory path", () => {
     expect(visitedDirsCache.has("/project/src/app")).toBe(false);
     expect(visitedDirsCache.has("/project/src/app/foo")).toBe(false);
 
-    // Descendant should not be removed
     expect(visitedDirsCache.has("/project/src/app/foo/bar")).toBe(true);
-    // Unrelated entry remains
     expect(visitedDirsCache.has("/project/other")).toBe(true);
   });
 
-  it("should work correctly even if the target directory has a trailing slash", () => {
+  it("handles trailing slash in target directory", () => {
     clearVisitedDirsCacheAbove("/project/src/app/foo/");
 
     expect(visitedDirsCache.has("/project")).toBe(false);
@@ -53,51 +46,28 @@ describe("clearVisitedDirsCacheAbove - when given a directory path", () => {
     expect(visitedDirsCache.has("/project/other")).toBe(true);
   });
 
-  it("should not remove anything if the target directory has no matching ancestor in the cache", () => {
-    // Non-existent path "/not/exist"
+  it("does not remove anything if no matching ancestor", () => {
     clearVisitedDirsCacheAbove("/not/exist");
-
-    // None of the 6 pre-registered entries should be affected
     expect(visitedDirsCache.size).toBe(6);
   });
 
-  it("should work correctly with relative paths", () => {
+  it("works with relative paths", () => {
     const relativeTarget = "./project/src/app/foo";
     const absoluteTarget = path.resolve(relativeTarget);
 
-    // Add additional entries
     visitedDirsCache.set(absoluteTarget, true);
     visitedDirsCache.set(path.join(absoluteTarget, "subdir"), true);
 
     clearVisitedDirsCacheAbove(relativeTarget);
 
-    // Ancestors (resolved as absolute path) should be removed
     expect(visitedDirsCache.has(absoluteTarget)).toBe(false);
-    // Descendant should not be removed
     expect(visitedDirsCache.has(path.join(absoluteTarget, "subdir"))).toBe(
       true
     );
   });
-});
 
-describe("clearVisitedDirsCacheAbove - when given a file path", () => {
-  beforeEach(() => {
-    visitedDirsCache.clear();
-
-    // Set up cache entries
-    visitedDirsCache.set("/project", true);
-    visitedDirsCache.set("/project/src", true);
-    visitedDirsCache.set("/project/src/app", true);
-    visitedDirsCache.set("/project/src/app/foo", true);
-    visitedDirsCache.set("/project/src/app/foo/bar", true);
-    visitedDirsCache.set("/project/other", true);
-  });
-
-  it("should remove the parent directory of the file and all its ancestor directories", () => {
+  it("removes parent directory and ancestors when given a file path", () => {
     const filePath = "/project/src/app/foo/file.txt";
-    // The target becomes "/project/src/app/foo"
-    // Expect: /project, /project/src, /project/src/app, and /project/src/app/foo to be removed
-    //         Descendants like /project/src/app/foo/bar should remain
     clearVisitedDirsCacheAbove(filePath);
 
     expect(visitedDirsCache.has("/project")).toBe(false);
@@ -109,7 +79,7 @@ describe("clearVisitedDirsCacheAbove - when given a file path", () => {
     expect(visitedDirsCache.has("/project/other")).toBe(true);
   });
 
-  it("should not remove anything if the file does not exist", () => {
+  it("does nothing if file path has no match", () => {
     const filePath = "/non/existent/file.txt";
     const originalSize = visitedDirsCache.size;
     clearVisitedDirsCacheAbove(filePath);
@@ -118,32 +88,94 @@ describe("clearVisitedDirsCacheAbove - when given a file path", () => {
 });
 
 describe("clearCntCache", () => {
-  // Clear cache before each test
   beforeEach(() => {
     clearCntCache();
   });
 
-  it("should remove all keys from cntCache when populated", () => {
-    // Set sample data to cntCache
+  it("clears populated cntCache", () => {
     cntCache["key1"] = 10;
     cntCache["key2"] = 20;
 
-    // Ensure values are set
     expect(Object.keys(cntCache)).toHaveLength(2);
-
-    // Execute clearCntCache
     clearCntCache();
-
-    // Ensure cntCache is empty
     expect(Object.keys(cntCache)).toHaveLength(0);
   });
 
-  it("should work correctly when cntCache is already empty", () => {
-    // Ensure initial state is empty
+  it("works even if cntCache is already empty", () => {
     expect(Object.keys(cntCache)).toHaveLength(0);
-
-    // Execute clearCntCache without error and still empty
     clearCntCache();
     expect(Object.keys(cntCache)).toHaveLength(0);
+  });
+});
+
+describe("clearScanAppDirCacheAbove", () => {
+  beforeEach(() => {
+    const blunkObj = {
+      pathStructure: "",
+      imports: [],
+      paramsTypes: [],
+    };
+    scanAppDirCache.clear();
+    scanAppDirCache.set("/project", blunkObj);
+    scanAppDirCache.set("/project/src", blunkObj);
+    scanAppDirCache.set("/project/src/app", blunkObj);
+    scanAppDirCache.set("/project/other", blunkObj);
+  });
+
+  it("removes target directory and its ancestors from scanAppDirCache", () => {
+    clearScanAppDirCacheAbove("/project/src/app");
+
+    expect(scanAppDirCache.has("/project")).toBe(false);
+    expect(scanAppDirCache.has("/project/src")).toBe(false);
+    expect(scanAppDirCache.has("/project/src/app")).toBe(false);
+    expect(scanAppDirCache.has("/project/other")).toBe(true);
+  });
+
+  it("does nothing if no matching ancestor exists", () => {
+    const size = scanAppDirCache.size;
+    clearScanAppDirCacheAbove("/no/match");
+    expect(scanAppDirCache.size).toBe(size);
+  });
+});
+
+describe("clearVisitedDirsCacheAbove - additional cases", () => {
+  it("does nothing if visitedDirsCache is empty", () => {
+    visitedDirsCache.clear();
+    clearVisitedDirsCacheAbove("/any/path");
+    expect(visitedDirsCache.size).toBe(0);
+  });
+
+  it("does not remove entries when target is not related at all", () => {
+    visitedDirsCache.clear();
+    visitedDirsCache.set("/unrelated/path", true);
+    clearVisitedDirsCacheAbove("/totally/different");
+    expect(visitedDirsCache.has("/unrelated/path")).toBe(true);
+  });
+
+  it("handles root directory correctly", () => {
+    visitedDirsCache.clear();
+    visitedDirsCache.set("/", true);
+    visitedDirsCache.set("/foo", true);
+    clearVisitedDirsCacheAbove("/");
+    expect(visitedDirsCache.has("/")).toBe(false);
+    expect(visitedDirsCache.has("/foo")).toBe(true);
+  });
+
+  it("handles directory paths containing '../'", () => {
+    visitedDirsCache.clear();
+    visitedDirsCache.set("/project/src", true);
+    visitedDirsCache.set("/project/src/app", true);
+    clearVisitedDirsCacheAbove("/project/src/app/../app");
+    expect(visitedDirsCache.has("/project/src")).toBe(false);
+    expect(visitedDirsCache.has("/project/src/app")).toBe(false);
+  });
+
+  it("does not mistakenly delete similar looking directories", () => {
+    visitedDirsCache.clear();
+    visitedDirsCache.set("/project/src", true);
+    visitedDirsCache.set("/project2/src", true);
+    clearVisitedDirsCacheAbove("/project/src/app");
+    expect(visitedDirsCache.has("/project/src")).toBe(false);
+    expect(visitedDirsCache.has("/project2/src")).toBe(true);
   });
 });

--- a/src/cli/core/cache.ts
+++ b/src/cli/core/cache.ts
@@ -1,38 +1,41 @@
 import path from "path";
 import type { scanAppDir } from "./route-scanner";
 
+// Caches
 export const visitedDirsCache = new Map<string, boolean>();
-export const cntCache = {} as Record<string, number>;
 export const scanAppDirCache = new Map<string, ReturnType<typeof scanAppDir>>();
+export const cntCache: Record<string, number> = {};
 
-export const clearCntCache = () => {
-  Object.keys(cntCache).forEach((key) => delete cntCache[key]);
+// Clear count cache
+export const clearCntCache = (): void => {
+  Object.keys(cntCache).forEach((key) => {
+    delete cntCache[key];
+  });
 };
 
-export const clearVisitedDirsCacheAbove = (targetPath: string) => {
+// Generic function to clear cache entries above a target path
+const clearCacheAbove = (
+  cache: Map<string, unknown>,
+  targetPath: string
+): void => {
   const basePath = path.resolve(targetPath);
 
-  for (const key of visitedDirsCache.keys()) {
+  [...cache.keys()].forEach((key) => {
     const normalizedKey = path.resolve(key);
     if (
       normalizedKey === basePath ||
       basePath.startsWith(normalizedKey + path.sep)
     ) {
-      visitedDirsCache.delete(key);
+      cache.delete(key);
     }
-  }
+  });
 };
 
-export const clearScanAppDirCache = (targetPath: string) => {
-  const basePath = path.resolve(targetPath);
+// Specific clear functions using the generic one
+export const clearVisitedDirsCacheAbove = (targetPath: string): void => {
+  clearCacheAbove(visitedDirsCache, targetPath);
+};
 
-  for (const key of scanAppDirCache.keys()) {
-    const normalizedKey = path.resolve(key);
-    if (
-      normalizedKey === basePath ||
-      basePath.startsWith(normalizedKey + path.sep)
-    ) {
-      scanAppDirCache.delete(key);
-    }
-  }
+export const clearScanAppDirCacheAbove = (targetPath: string): void => {
+  clearCacheAbove(scanAppDirCache, targetPath);
 };

--- a/src/cli/core/cache.ts
+++ b/src/cli/core/cache.ts
@@ -4,14 +4,6 @@ import type { scanAppDir } from "./route-scanner";
 // Caches
 export const visitedDirsCache = new Map<string, boolean>();
 export const scanAppDirCache = new Map<string, ReturnType<typeof scanAppDir>>();
-export const cntCache: Record<string, number> = {};
-
-// Clear count cache
-export const clearCntCache = (): void => {
-  Object.keys(cntCache).forEach((key) => {
-    delete cntCache[key];
-  });
-};
 
 // Generic function to clear cache entries above a target path
 const clearCacheAbove = (

--- a/src/cli/core/cache.ts
+++ b/src/cli/core/cache.ts
@@ -1,7 +1,9 @@
 import path from "path";
+import type { scanAppDir } from "./route-scanner";
 
 export const visitedDirsCache = new Map<string, boolean>();
 export const cntCache = {} as Record<string, number>;
+export const scanAppDirCache = new Map<string, ReturnType<typeof scanAppDir>>();
 
 export const clearCntCache = () => {
   Object.keys(cntCache).forEach((key) => delete cntCache[key]);
@@ -17,6 +19,20 @@ export const clearVisitedDirsCacheAbove = (targetPath: string) => {
       basePath.startsWith(normalizedKey + path.sep)
     ) {
       visitedDirsCache.delete(key);
+    }
+  }
+};
+
+export const clearScanAppDirCache = (targetPath: string) => {
+  const basePath = path.resolve(targetPath);
+
+  for (const key of scanAppDirCache.keys()) {
+    const normalizedKey = path.resolve(key);
+    if (
+      normalizedKey === basePath ||
+      basePath.startsWith(normalizedKey + path.sep)
+    ) {
+      scanAppDirCache.delete(key);
     }
   }
 };

--- a/src/cli/core/route-scanner.test.ts
+++ b/src/cli/core/route-scanner.test.ts
@@ -1,5 +1,11 @@
 import mock from "mock-fs";
 import { describe, beforeEach, afterEach, it, expect } from "vitest";
+import {
+  clearCntCache,
+  clearScanAppDirCache,
+  scanAppDirCache,
+  visitedDirsCache,
+} from "./cache";
 import { hasTargetFiles, scanAppDir } from "./route-scanner";
 
 describe("hasTargetFiles", () => {
@@ -90,6 +96,7 @@ describe("hasTargetFiles", () => {
 describe("scanAppDir", () => {
   afterEach(() => {
     mock.restore();
+    scanAppDirCache.clear();
   });
 
   it("should scan API directory and generate path structure with multiple HTTP methods, excluding OPTIONS", () => {
@@ -121,7 +128,6 @@ describe("scanAppDir", () => {
     }
   }
 }`;
-
     const { pathStructure, imports, paramsTypes } = scanAppDir(
       "/output",
       "/testApp"
@@ -205,7 +211,6 @@ describe("scanAppDir", () => {
     }
   }
 }`;
-
     const { pathStructure } = scanAppDir("/output", "/testApp");
     expect(pathStructure).equals(expectPathStructure);
   });
@@ -227,7 +232,6 @@ describe("scanAppDir", () => {
     "home": Record<QueryKey, Query_0> & Endpoint
   }
 }`;
-
     const { pathStructure } = scanAppDir("/output", "/testApp");
     expect(pathStructure).equals(expectPathStructure);
   });
@@ -256,7 +260,6 @@ describe("scanAppDir", () => {
     }
   }
 }`;
-
     const { pathStructure } = scanAppDir("/output", "/testApp");
     expect(pathStructure).equals(expectPathStructure);
   });
@@ -281,7 +284,6 @@ describe("scanAppDir", () => {
     }
   }
 }`;
-
     const { pathStructure } = scanAppDir("/output", "/testApp");
     expect(pathStructure).equals(expectPathStructure);
   });
@@ -306,7 +308,6 @@ describe("scanAppDir", () => {
     }
   }
 }`;
-
     const { pathStructure } = scanAppDir("/output", "/testApp");
     expect(pathStructure).equals(expectPathStructure);
   });
@@ -329,7 +330,6 @@ describe("scanAppDir", () => {
     "home": Endpoint
   }
 }`;
-
     const { pathStructure } = scanAppDir("/output", "/testApp");
     expect(pathStructure).equals(expectPathStructure);
   });
@@ -352,7 +352,6 @@ describe("scanAppDir", () => {
     "home": Endpoint
   }
 }`;
-
     const { pathStructure } = scanAppDir("/output", "/testApp");
     expect(pathStructure).equals(expectPathStructure);
   });
@@ -389,7 +388,6 @@ describe("scanAppDir", () => {
     const expectPathStructure = `{
   "base": Endpoint
 }`;
-
     const { pathStructure } = scanAppDir("/output", "/testApp");
     expect(pathStructure).equals(expectPathStructure);
   });
@@ -411,7 +409,6 @@ describe("scanAppDir", () => {
     const expectPathStructure = `{
   "base": Endpoint
 }`;
-
     const { pathStructure } = scanAppDir("/output", "/testApp");
     expect(pathStructure).equals(expectPathStructure);
   });
@@ -458,5 +455,631 @@ describe("scanAppDir", () => {
     expectedParamsTypes.forEach((paramsType, i) => {
       expect(paramsTypes[i]).toStrictEqual(paramsType);
     });
+  });
+});
+
+describe("scanAppDirCache", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("should return the same cached result for the same directory", () => {
+    mock({
+      "/testApp": {
+        "page.tsx": "export function Page() {};",
+      },
+    });
+
+    const result1 = scanAppDir("/output", "/testApp");
+    const result2 = scanAppDir("/output", "/testApp");
+    expect(result1).toBe(result2);
+  });
+
+  it("should clear cache when clearScanAppDirCache is called with the exact path", () => {
+    mock({
+      "/testApp": {
+        "page.tsx": "export function Page() {};",
+      },
+    });
+
+    const result1 = scanAppDir("/output", "/testApp");
+    clearScanAppDirCache("/testApp");
+    const result2 = scanAppDir("/output", "/testApp");
+    expect(result1).not.toBe(result2);
+  });
+
+  it("should clear parent cache when clearScanAppDirCache is called with a subdirectory", () => {
+    mock({
+      "/testApp": {
+        "page.tsx": "export function Page() {};",
+        sub: {
+          "index.ts": "export default function Index() {};",
+        },
+      },
+    });
+
+    const parentResult1 = scanAppDir("/output", "/testApp");
+    const childResult1 = scanAppDir("/output", "/testApp/sub");
+
+    // Clear cache by indicating a change in the subdirectory.
+    clearScanAppDirCache("/testApp/sub");
+
+    const parentResult2 = scanAppDir("/output", "/testApp");
+    const childResult2 = scanAppDir("/output", "/testApp/sub");
+
+    expect(parentResult1).not.toBe(parentResult2);
+    expect(childResult1).not.toBe(childResult2);
+  });
+
+  it("should not clear any cache if clearScanAppDirCache is called with a non-matching path", () => {
+    mock({
+      "/testApp": {
+        "page.tsx": "export function Page() {};",
+      },
+      "/another": {
+        "index.ts": "export function Index() {};",
+      },
+    });
+
+    const resultTestApp1 = scanAppDir("/output", "/testApp");
+    const resultAnother1 = scanAppDir("/output", "/another");
+
+    // Call clear with a path that doesn't match any cached entry.
+    clearScanAppDirCache("/nonexistent");
+
+    const resultTestApp2 = scanAppDir("/output", "/testApp");
+    const resultAnother2 = scanAppDir("/output", "/another");
+
+    expect(resultTestApp1).toBe(resultTestApp2);
+    expect(resultAnother1).toBe(resultAnother2);
+  });
+});
+
+describe("scanAppDirCache modification scenarios - detailed verification", () => {
+  beforeEach(() => {
+    scanAppDirCache.clear();
+    visitedDirsCache.clear();
+    clearCntCache();
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("should generate correct output when the lowest-level file is modified", () => {
+    // 初回スキャン：最下層のファイル (page.tsx) で Endpoint として認識される
+    mock({
+      "/testApp": {
+        sub: {
+          "page.tsx": "export function Page() {};",
+        },
+      },
+    });
+    const initial = scanAppDir("/output", "/testApp");
+    const expectedInitial = `{
+  "sub": Endpoint
+}`;
+
+    expect(initial.pathStructure).toBe(expectedInitial);
+
+    // 変更後：同じファイルの内容を route 定義に変更（GET メソッドが検出される）
+    mock.restore();
+    mock({
+      "/testApp": {
+        sub: {
+          "page.tsx": "export function GET() {};",
+        },
+      },
+    });
+    // 変更されたファイルのパスを指定してキャッシュクリア
+    clearScanAppDirCache("/testApp/sub/page.tsx");
+    const modified = scanAppDir("/output", "/testApp");
+    const expectedModified = `{
+  "sub": { "$get": typeof GET_0 } & Endpoint
+}`;
+    expect(modified.pathStructure).toBe(expectedModified);
+  });
+
+  it("should generate correct output when a mid-level file is modified", () => {
+    // 初回スキャン：中間層のファイル (page.tsx) で Endpoint として認識される
+    mock({
+      "/testApp": {
+        mid: {
+          "page.tsx": "export function Page() {};",
+        },
+      },
+    });
+    const initial = scanAppDir("/output", "/testApp");
+    const expectedInitial = `{
+  "mid": Endpoint
+}`;
+    expect(initial.pathStructure).toBe(expectedInitial);
+
+    // 変更後：中間層のファイル内容を変更して GET メソッドが検出される
+    mock.restore();
+    mock({
+      "/testApp": {
+        mid: {
+          "page.tsx": "export function GET() {};",
+        },
+      },
+    });
+    clearScanAppDirCache("/testApp/mid/page.tsx");
+    const modified = scanAppDir("/output", "/testApp");
+    const expectedModified = `{
+  "mid": { "$get": typeof GET_0 } & Endpoint
+}`;
+    expect(modified.pathStructure).toBe(expectedModified);
+  });
+
+  it("should generate correct output when a top-level file is modified", () => {
+    // 初回スキャン：トップレベルのファイル (index.ts) で Endpoint として認識される
+    mock({
+      "/testApp": {
+        "route.ts": "export default function Index() {};",
+      },
+    });
+    const initial = scanAppDir("/output", "/testApp");
+    const expectedInitial = `Endpoint`;
+    expect(initial.pathStructure).toBe(expectedInitial);
+
+    // 変更後：同じファイル内容を変更して GET メソッドが検出される
+    mock.restore();
+    mock({
+      "/testApp": {
+        "route.ts": "export function GET() {};",
+      },
+    });
+    clearScanAppDirCache("/testApp/index.ts");
+    const modified = scanAppDir("/output", "/testApp");
+    const expectedModified = `{ "$get": typeof GET_0 } & Endpoint`;
+    expect(modified.pathStructure).toBe(expectedModified);
+  });
+
+  it("should generate correct output when a folder is added in the lowest-level directory", () => {
+    // 初回スキャン：/testApp/sub に1ファイルのみが存在
+    mock({
+      "/testApp": {
+        sub: {
+          "page.tsx": "export function Page() {};",
+        },
+      },
+    });
+    const initial = scanAppDir("/output", "/testApp");
+    const expectedInitial = `{
+  "sub": Endpoint
+}`;
+    expect(initial.pathStructure).toBe(expectedInitial);
+
+    // 変更後：/testApp/sub に新たなフォルダ newFolder が追加され、その中にファイルが存在する
+    mock.restore();
+    mock({
+      "/testApp": {
+        sub: {
+          "page.tsx": "export function Page() {};",
+          newFolder: {
+            "page.tsx": "export function NewPage() {};",
+          },
+        },
+      },
+    });
+    clearScanAppDirCache("/testApp/sub/newFolder");
+    const modified = scanAppDir("/output", "/testApp");
+    // ※ 内部では sub 以下で page.tsx から Endpoint、newFolder からも Endpoint が生成される
+    const expectedModified = `{
+  "sub": Endpoint & {
+    "newFolder": Endpoint
+  }
+}`;
+    expect(modified.pathStructure).toBe(expectedModified);
+  });
+
+  it("should generate correct output when a folder is added in a mid-level directory", () => {
+    // 初回スキャン：/testApp/mid/sub に1ファイルのみが存在
+    mock({
+      "/testApp": {
+        mid: {
+          sub: {
+            "page.tsx": "export function Page() {};",
+          },
+        },
+      },
+    });
+    const initial = scanAppDir("/output", "/testApp");
+    const expectedInitial = `{
+  "mid": {
+    "sub": Endpoint
+  }
+}`;
+    expect(initial.pathStructure).toBe(expectedInitial);
+
+    // 変更後：/testApp/mid に新たなフォルダ newFolder が追加され、その中にファイルが存在する
+    mock.restore();
+    mock({
+      "/testApp": {
+        mid: {
+          sub: {
+            "page.tsx": "export function Page() {};",
+          },
+          newFolder: {
+            "page.tsx": "export default function NewPage() {};",
+          },
+        },
+      },
+    });
+    clearScanAppDirCache("/testApp/mid/newFolder");
+    const modified = scanAppDir("/output", "/testApp");
+    // sorting により、ディレクトリ名がアルファベット順で並ぶ (newFolder < sub)
+    const expectedModified = `{
+  "mid": {
+    "newFolder": Endpoint,
+    "sub": Endpoint
+  }
+}`;
+    expect(modified.pathStructure).toBe(expectedModified);
+  });
+
+  it("should generate correct output when a folder is added in the top-level directory", () => {
+    // 初回スキャン：/testApp にトップレベルのファイルのみが存在
+    mock({
+      "/testApp": {
+        "route.ts": "export default function Index() {};",
+      },
+    });
+    const initial = scanAppDir("/output", "/testApp");
+    const expectedInitial = `Endpoint`;
+    expect(initial.pathStructure).toBe(expectedInitial);
+
+    // 変更後：/testApp に新たなフォルダ newFolder が追加され、その中にファイルが存在する
+    mock.restore();
+    mock({
+      "/testApp": {
+        "route.ts": "export default function Index() {};",
+        newFolder: {
+          "page.tsx": "export function NewPage() {};",
+        },
+      },
+    });
+    clearScanAppDirCache("/testApp/newFolder");
+    const modified = scanAppDir("/output", "/testApp");
+    const expectedModified = `Endpoint & {
+  "newFolder": Endpoint
+}`;
+    expect(modified.pathStructure).toBe(expectedModified);
+  });
+});
+
+describe("scanAppDirCache dynamic folder scenarios - detailed verification", () => {
+  beforeEach(() => {
+    scanAppDirCache.clear();
+    visitedDirsCache.clear();
+    clearCntCache();
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("should generate correct output when a single dynamic folder is inserted in between", () => {
+    // 初期状態: /testApp/[user]/home/page.tsx
+    mock({
+      "/testApp": {
+        "[user]": {
+          home: {
+            "page.tsx": "export function Page() {};",
+          },
+        },
+      },
+    });
+    const initial = scanAppDir("/output", "/testApp");
+    const expectedInitial = `{
+  "_user": {
+    "home": Endpoint & Record<ParamsKey, { "user": string }>
+  }
+}`;
+    expect(initial.pathStructure).toBe(expectedInitial);
+
+    // 変更後: ダイナミックフォルダを1段追加
+    // → /testApp/[user]/[id]/home/page.tsx
+    mock.restore();
+    mock({
+      "/testApp": {
+        "[user]": {
+          "[id]": {
+            home: {
+              "page.tsx": "export function Page() {};",
+            },
+          },
+        },
+      },
+    });
+    // 追加された部分のキャッシュをクリア（※子ディレクトリのキャッシュを削除すれば上位も再生成される）
+    clearScanAppDirCache("/testApp/[user]/[id]");
+    const modified = scanAppDir("/output", "/testApp");
+    const expectedModified = `{
+  "_user": {
+    "_id": {
+      "home": Endpoint & Record<ParamsKey, { "user": string; "id": string; }>
+    }
+  }
+}`;
+    expect(modified.pathStructure).toBe(expectedModified);
+  });
+
+  it("should generate correct output when multiple dynamic folders are added in between", () => {
+    // 初期状態: /testApp/[user]/home/page.tsx
+    mock({
+      "/testApp": {
+        "[user]": {
+          home: {
+            "page.tsx": "export function Page() {};",
+          },
+        },
+      },
+    });
+    const initial = scanAppDir("/output", "/testApp");
+    const expectedInitial = `{
+  "_user": {
+    "home": Endpoint & Record<ParamsKey, { "user": string }>
+  }
+}`;
+    expect(initial.pathStructure).toBe(expectedInitial);
+
+    // 変更後: 複数のダイナミックフォルダを挿入
+    // → /testApp/[user]/[id]/[detail]/home/page.tsx
+    mock.restore();
+    mock({
+      "/testApp": {
+        "[user]": {
+          "[id]": {
+            "[detail]": {
+              home: {
+                "page.tsx": "export function Page() {};",
+              },
+            },
+          },
+        },
+      },
+    });
+    clearScanAppDirCache("/testApp/[user]/[id]");
+    const modified = scanAppDir("/output", "/testApp");
+    const expectedModified = `{
+  "_user": {
+    "_id": {
+      "_detail": {
+        "home": Endpoint & Record<ParamsKey, { "user": string; "id": string; "detail": string; }>
+      }
+    }
+  }
+}`;
+    expect(modified.pathStructure).toBe(expectedModified);
+  });
+
+  it("should generate correct output when a dynamic folder is inserted in the middle of an already multi-folder dynamic structure", () => {
+    // 初期状態: /testApp/[user]/[id]/home/page.tsx
+    mock({
+      "/testApp": {
+        "[user]": {
+          "[id]": {
+            home: {
+              "page.tsx": "export function Page() {};",
+            },
+          },
+        },
+      },
+    });
+    const initial = scanAppDir("/output", "/testApp");
+    const expectedInitial = `{
+  "_user": {
+    "_id": {
+      "home": Endpoint & Record<ParamsKey, { "user": string; "id": string; }>
+    }
+  }
+}`;
+    expect(initial.pathStructure).toBe(expectedInitial);
+
+    // 変更後: 既存の2段階の間にもう1段階挿入
+    // → /testApp/[user]/[lang]/[id]/home/page.tsx
+    mock.restore();
+    mock({
+      "/testApp": {
+        "[user]": {
+          "[lang]": {
+            "[id]": {
+              home: {
+                "page.tsx": "export function Page() {};",
+              },
+            },
+          },
+        },
+      },
+    });
+    clearScanAppDirCache("/testApp/[user]/[lang]");
+    const modified = scanAppDir("/output", "/testApp");
+    const expectedModified = `{
+  "_user": {
+    "_lang": {
+      "_id": {
+        "home": Endpoint & Record<ParamsKey, { "user": string; "lang": string; "id": string; }>
+      }
+    }
+  }
+}`;
+    expect(modified.pathStructure).toBe(expectedModified);
+  });
+});
+
+describe("scanAppDirCache multiple child directories scenarios", () => {
+  beforeEach(() => {
+    scanAppDirCache.clear();
+    visitedDirsCache.clear();
+    clearCntCache();
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("should generate correct output when multiple child directories exist and one branch is modified with an additional dynamic folder", () => {
+    // 初期状態:
+    // /testApp
+    //   [user]/home/page.tsx   → dynamic: "[user]" → "_user" として処理される
+    //   static/home/page.tsx     → 静的ディレクトリ "static"
+    mock({
+      "/testApp": {
+        "[user]": {
+          home: {
+            "page.tsx": "export function Page() {};",
+          },
+        },
+        "[admin]": {
+          home: {
+            "page.tsx": "export function Page() {};",
+          },
+        },
+        static: {
+          home: {
+            "page.tsx": "export function Page() {};",
+          },
+        },
+      },
+    });
+    const initial = scanAppDir("/output", "/testApp");
+    // sorted順はファイルシステムのデフォルトの lexicographical ソートに従い、"[user]" は _user、"static" はそのまま "static"
+    const expectedInitial = `{
+  "_admin": {
+    "home": Endpoint & Record<ParamsKey, { "admin": string }>
+  },
+  "_user": {
+    "home": Endpoint & Record<ParamsKey, { "user": string }>
+  },
+  "static": {
+    "home": Endpoint
+  }
+}`;
+    expect(initial.pathStructure).toBe(expectedInitial);
+
+    // 変更後: [user] ブランチに動的フォルダ [id] を追加して
+    // /testApp
+    //   [user]/[id]/home/page.tsx   → _user/_id の階層に変化
+    //   static/home/page.tsx         → 変更なし
+    mock.restore();
+    mock({
+      "/testApp": {
+        "[admin]": {
+          "[id]": {
+            home: {
+              "page.tsx": "export function Page() {};",
+            },
+          },
+        },
+        "[user]": {
+          "[id]": {
+            home: {
+              "page.tsx": "export function Page() {};",
+            },
+          },
+        },
+        static: {
+          home: {
+            "page.tsx": "export function Page() {};",
+          },
+        },
+      },
+    });
+    // 追加された動的フォルダのパスを指定してキャッシュクリア
+    clearScanAppDirCache("/testApp/[admin]/[id]");
+    clearScanAppDirCache("/testApp/[user]/[id]");
+    const modified = scanAppDir("/output", "/testApp");
+    const expectedModified = `{
+  "_admin": {
+    "_id": {
+      "home": Endpoint & Record<ParamsKey, { "admin": string; "id": string; }>
+    }
+  },
+  "_user": {
+    "_id": {
+      "home": Endpoint & Record<ParamsKey, { "user": string; "id": string; }>
+    }
+  },
+  "static": {
+    "home": Endpoint
+  }
+}`;
+    expect(modified.pathStructure).toBe(expectedModified);
+  });
+
+  it("should generate correct output when multiple child directories exist and both branches are modified with additional dynamic folders", () => {
+    // 初期状態:
+    // /testApp
+    //   [user]/home/page.tsx      → _user
+    //   [group]/dashboard/page.tsx → _group
+    // ※ 両方とも動的フォルダのため、各ブランチは Record<ParamsKey, …> が付与される
+    mock({
+      "/testApp": {
+        "[user]": {
+          home: {
+            "page.tsx": "export function Page() {};",
+          },
+        },
+        "[group]": {
+          dashboard: {
+            "page.tsx": "export function Page() {};",
+          },
+        },
+      },
+    });
+    const initial = scanAppDir("/output", "/testApp");
+    // ソート順："[group]" が先、"[user]" が後になる想定
+    const expectedInitial = `{
+  "_group": {
+    "dashboard": Endpoint & Record<ParamsKey, { "group": string }>
+  },
+  "_user": {
+    "home": Endpoint & Record<ParamsKey, { "user": string }>
+  }
+}`;
+    expect(initial.pathStructure).toBe(expectedInitial);
+
+    // 変更後: 両ブランチに追加の動的フォルダ [id] を挿入
+    // /testApp
+    //   [user]/[id]/home/page.tsx      → _user/_id
+    //   [group]/[id]/dashboard/page.tsx  → _group/_id
+    mock.restore();
+    mock({
+      "/testApp": {
+        "[user]": {
+          "[id]": {
+            home: {
+              "page.tsx": "export function Page() {};",
+            },
+          },
+        },
+        "[group]": {
+          "[id]": {
+            dashboard: {
+              "page.tsx": "export function Page() {};",
+            },
+          },
+        },
+      },
+    });
+    // キャッシュクリア：両方の追加されたパスをクリアすれば上位も再生成される
+    clearScanAppDirCache("/testApp/[user]/[id]");
+    clearScanAppDirCache("/testApp/[group]/[id]");
+    const modified = scanAppDir("/output", "/testApp");
+    const expectedModified = `{
+  "_group": {
+    "_id": {
+      "dashboard": Endpoint & Record<ParamsKey, { "group": string; "id": string; }>
+    }
+  },
+  "_user": {
+    "_id": {
+      "home": Endpoint & Record<ParamsKey, { "user": string; "id": string; }>
+    }
+  }
+}`;
+    expect(modified.pathStructure).toBe(expectedModified);
   });
 });

--- a/src/cli/core/route-scanner.test.ts
+++ b/src/cli/core/route-scanner.test.ts
@@ -8,8 +8,12 @@ import {
 } from "./cache";
 import { hasTargetFiles, scanAppDir } from "./route-scanner";
 
+// ----------------------
+// Test for hasTargetFiles
+// ----------------------
 describe("hasTargetFiles", () => {
   beforeEach(() => {
+    // Prepare mock file system
     mock({
       "/testDir": {
         "file1.ts": "console.log('test');",
@@ -65,6 +69,7 @@ describe("hasTargetFiles", () => {
   });
 
   afterEach(() => {
+    // Restore original file system after each test
     mock.restore();
   });
 
@@ -81,7 +86,7 @@ describe("hasTargetFiles", () => {
     expect(result2).toBe(false);
   });
 
-  it("should return false if except directory", () => {
+  it("should return false if the directory is one of the except directories", () => {
     const result = hasTargetFiles("/except/intercepts");
     expect(result).toBe(false);
 
@@ -93,13 +98,18 @@ describe("hasTargetFiles", () => {
   });
 });
 
+// ----------------------
+// Test for scanAppDir
+// ----------------------
 describe("scanAppDir", () => {
   afterEach(() => {
+    // Cleanup
     mock.restore();
     scanAppDirCache.clear();
   });
 
   it("should scan API directory and generate path structure with multiple HTTP methods, excluding OPTIONS", () => {
+    // Setup API directory with multiple HTTP methods including OPTIONS
     mock({
       "/testApp": {
         api: {
@@ -113,7 +123,7 @@ describe("scanAppDir", () => {
                 export function DELETE() {};
                 export function PATCH() {};
                 export function HEAD() {};
-                export function OPTIONS() {}; // This should be ignored
+                export function OPTIONS() {}; // Should be ignored
               `,
             },
           },
@@ -121,6 +131,7 @@ describe("scanAppDir", () => {
       },
     });
 
+    // Expected path structure
     const expectPathStructure = `{
   "api": {
     "users": {
@@ -132,8 +143,10 @@ describe("scanAppDir", () => {
       "/output",
       "/testApp"
     );
+
     expect(pathStructure).equals(expectPathStructure);
 
+    // Should import 6 methods excluding OPTIONS
     expect(imports).toHaveLength(6);
 
     const expectedImports = [
@@ -177,6 +190,7 @@ describe("scanAppDir", () => {
       true
     );
 
+    // Parameter types
     expect(paramsTypes).toHaveLength(1);
 
     const expectedParamsTypes = [
@@ -191,7 +205,8 @@ describe("scanAppDir", () => {
     });
   });
 
-  it("should scan page directory and generate path structure with dynamic segmente", () => {
+  it("should scan page directory and generate path structure with dynamic segment", () => {
+    // Setup dynamic segment
     mock({
       "/testApp": {
         page: {
@@ -216,6 +231,7 @@ describe("scanAppDir", () => {
   });
 
   it("should generate path structure with query type", () => {
+    // Setup page containing a Query type
     mock({
       "/testApp": {
         query: {
@@ -236,7 +252,8 @@ describe("scanAppDir", () => {
     expect(pathStructure).equals(expectPathStructure);
   });
 
-  it("sshould scan directory with multiple dynamic segments and generate path structure", () => {
+  it("should scan directory with multiple dynamic segments and generate path structure", () => {
+    // Setup multiple dynamic segments
     mock({
       "/testApp": {
         dynamic: {
@@ -265,6 +282,7 @@ describe("scanAppDir", () => {
   });
 
   it("should scan directory with catch-all routes and generate path structure", () => {
+    // Setup catch-all routes
     mock({
       "/testApp": {
         catchAll: {
@@ -289,6 +307,7 @@ describe("scanAppDir", () => {
   });
 
   it("should scan directory with optional catch-all routes and generate path structure", () => {
+    // Setup optional catch-all routes
     mock({
       "/testApp": {
         OptionalCatchAll: {
@@ -313,6 +332,7 @@ describe("scanAppDir", () => {
   });
 
   it("should scan directory with grouped routes and generate path structure", () => {
+    // Setup grouped routes
     mock({
       "/testApp": {
         group: {
@@ -335,6 +355,7 @@ describe("scanAppDir", () => {
   });
 
   it("should scan directory with parallel routes and generate path structure", () => {
+    // Setup parallel routes
     mock({
       "/testApp": {
         parallel: {
@@ -357,6 +378,7 @@ describe("scanAppDir", () => {
   });
 
   it("should scan directory with intercepting routes and generate path structure", () => {
+    // Setup intercepting routes
     mock({
       "/testApp": {
         intercepts: {
@@ -393,6 +415,7 @@ describe("scanAppDir", () => {
   });
 
   it("should scan private directory and generate path structure", () => {
+    // Setup private directory
     mock({
       "/testApp": {
         private: {
@@ -414,12 +437,14 @@ describe("scanAppDir", () => {
   });
 
   it("should handle empty directories gracefully", () => {
+    // Handle empty directories
     mock({ "/emptyDir": {} });
     const { pathStructure } = scanAppDir("/output", "/emptyDir");
     expect(pathStructure).toBe("");
   });
 
-  it("should handle multiple paramss", () => {
+  it("should handle multiple params", () => {
+    // Setup for multiple params
     mock({
       "/testApp": {
         OptionalCatchAll: {
@@ -458,12 +483,17 @@ describe("scanAppDir", () => {
   });
 });
 
+// ----------------------
+// Tests for scanAppDirCache
+// ----------------------
 describe("scanAppDirCache", () => {
   afterEach(() => {
+    // Cleanup
     mock.restore();
   });
 
   it("should return the same cached result for the same directory", () => {
+    // Result should be cached
     mock({
       "/testApp": {
         "page.tsx": "export function Page() {};",
@@ -476,6 +506,7 @@ describe("scanAppDirCache", () => {
   });
 
   it("should clear cache when clearScanAppDirCache is called with the exact path", () => {
+    // Clear by exact path
     mock({
       "/testApp": {
         "page.tsx": "export function Page() {};",
@@ -489,6 +520,7 @@ describe("scanAppDirCache", () => {
   });
 
   it("should clear parent cache when clearScanAppDirCache is called with a subdirectory", () => {
+    // Clear cache by subdirectory
     mock({
       "/testApp": {
         "page.tsx": "export function Page() {};",
@@ -501,7 +533,6 @@ describe("scanAppDirCache", () => {
     const parentResult1 = scanAppDir("/output", "/testApp");
     const childResult1 = scanAppDir("/output", "/testApp/sub");
 
-    // Clear cache by indicating a change in the subdirectory.
     clearScanAppDirCache("/testApp/sub");
 
     const parentResult2 = scanAppDir("/output", "/testApp");
@@ -512,6 +543,7 @@ describe("scanAppDirCache", () => {
   });
 
   it("should not clear any cache if clearScanAppDirCache is called with a non-matching path", () => {
+    // Clear with irrelevant path
     mock({
       "/testApp": {
         "page.tsx": "export function Page() {};",
@@ -524,7 +556,6 @@ describe("scanAppDirCache", () => {
     const resultTestApp1 = scanAppDir("/output", "/testApp");
     const resultAnother1 = scanAppDir("/output", "/another");
 
-    // Call clear with a path that doesn't match any cached entry.
     clearScanAppDirCache("/nonexistent");
 
     const resultTestApp2 = scanAppDir("/output", "/testApp");
@@ -535,8 +566,12 @@ describe("scanAppDirCache", () => {
   });
 });
 
+// ----------------------
+// Detailed scenarios for cache modification
+// ----------------------
 describe("scanAppDirCache modification scenarios - detailed verification", () => {
   beforeEach(() => {
+    // Clear all caches before each test
     scanAppDirCache.clear();
     visitedDirsCache.clear();
     clearCntCache();
@@ -547,7 +582,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
   });
 
   it("should generate correct output when the lowest-level file is modified", () => {
-    // 初回スキャン：最下層のファイル (page.tsx) で Endpoint として認識される
+    // First scan: recognized as an Endpoint from lowest-level file (page.tsx)
     mock({
       "/testApp": {
         sub: {
@@ -559,10 +594,9 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
     const expectedInitial = `{
   "sub": Endpoint
 }`;
-
     expect(initial.pathStructure).toBe(expectedInitial);
 
-    // 変更後：同じファイルの内容を route 定義に変更（GET メソッドが検出される）
+    // After modification: change to route definition with GET method
     mock.restore();
     mock({
       "/testApp": {
@@ -571,7 +605,6 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
         },
       },
     });
-    // 変更されたファイルのパスを指定してキャッシュクリア
     clearScanAppDirCache("/testApp/sub/page.tsx");
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
@@ -581,7 +614,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
   });
 
   it("should generate correct output when a mid-level file is modified", () => {
-    // 初回スキャン：中間層のファイル (page.tsx) で Endpoint として認識される
+    // First scan: recognized as an Endpoint from mid-level file
     mock({
       "/testApp": {
         mid: {
@@ -595,7 +628,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
 }`;
     expect(initial.pathStructure).toBe(expectedInitial);
 
-    // 変更後：中間層のファイル内容を変更して GET メソッドが検出される
+    // After modification: add GET method
     mock.restore();
     mock({
       "/testApp": {
@@ -613,7 +646,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
   });
 
   it("should generate correct output when a top-level file is modified", () => {
-    // 初回スキャン：トップレベルのファイル (index.ts) で Endpoint として認識される
+    // First scan: top-level file as Endpoint
     mock({
       "/testApp": {
         "route.ts": "export default function Index() {};",
@@ -623,7 +656,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
     const expectedInitial = `Endpoint`;
     expect(initial.pathStructure).toBe(expectedInitial);
 
-    // 変更後：同じファイル内容を変更して GET メソッドが検出される
+    // After modification: add GET method
     mock.restore();
     mock({
       "/testApp": {
@@ -635,9 +668,8 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
     const expectedModified = `{ "$get": typeof GET_0 } & Endpoint`;
     expect(modified.pathStructure).toBe(expectedModified);
   });
-
   it("should generate correct output when a folder is added in the lowest-level directory", () => {
-    // 初回スキャン：/testApp/sub に1ファイルのみが存在
+    // First scan: /testApp/sub has only one file
     mock({
       "/testApp": {
         sub: {
@@ -651,7 +683,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
 }`;
     expect(initial.pathStructure).toBe(expectedInitial);
 
-    // 変更後：/testApp/sub に新たなフォルダ newFolder が追加され、その中にファイルが存在する
+    // After modification: a new folder (newFolder) is added under /testApp/sub with a file
     mock.restore();
     mock({
       "/testApp": {
@@ -665,7 +697,6 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
     });
     clearScanAppDirCache("/testApp/sub/newFolder");
     const modified = scanAppDir("/output", "/testApp");
-    // ※ 内部では sub 以下で page.tsx から Endpoint、newFolder からも Endpoint が生成される
     const expectedModified = `{
   "sub": Endpoint & {
     "newFolder": Endpoint
@@ -675,7 +706,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
   });
 
   it("should generate correct output when a folder is added in a mid-level directory", () => {
-    // 初回スキャン：/testApp/mid/sub に1ファイルのみが存在
+    // First scan: /testApp/mid/sub has only one file
     mock({
       "/testApp": {
         mid: {
@@ -693,7 +724,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
 }`;
     expect(initial.pathStructure).toBe(expectedInitial);
 
-    // 変更後：/testApp/mid に新たなフォルダ newFolder が追加され、その中にファイルが存在する
+    // After modification: add newFolder under mid
     mock.restore();
     mock({
       "/testApp": {
@@ -709,7 +740,6 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
     });
     clearScanAppDirCache("/testApp/mid/newFolder");
     const modified = scanAppDir("/output", "/testApp");
-    // sorting により、ディレクトリ名がアルファベット順で並ぶ (newFolder < sub)
     const expectedModified = `{
   "mid": {
     "newFolder": Endpoint,
@@ -720,7 +750,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
   });
 
   it("should generate correct output when a folder is added in the top-level directory", () => {
-    // 初回スキャン：/testApp にトップレベルのファイルのみが存在
+    // First scan: /testApp has only a top-level file
     mock({
       "/testApp": {
         "route.ts": "export default function Index() {};",
@@ -730,7 +760,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
     const expectedInitial = `Endpoint`;
     expect(initial.pathStructure).toBe(expectedInitial);
 
-    // 変更後：/testApp に新たなフォルダ newFolder が追加され、その中にファイルが存在する
+    // After modification: add newFolder at the top level
     mock.restore();
     mock({
       "/testApp": {
@@ -749,6 +779,9 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
   });
 });
 
+// ----------------------
+// Tests for dynamic folder scenarios
+// ----------------------
 describe("scanAppDirCache dynamic folder scenarios - detailed verification", () => {
   beforeEach(() => {
     scanAppDirCache.clear();
@@ -761,7 +794,7 @@ describe("scanAppDirCache dynamic folder scenarios - detailed verification", () 
   });
 
   it("should generate correct output when a single dynamic folder is inserted in between", () => {
-    // 初期状態: /testApp/[user]/home/page.tsx
+    // Initial: /testApp/[user]/home/page.tsx
     mock({
       "/testApp": {
         "[user]": {
@@ -779,8 +812,7 @@ describe("scanAppDirCache dynamic folder scenarios - detailed verification", () 
 }`;
     expect(initial.pathStructure).toBe(expectedInitial);
 
-    // 変更後: ダイナミックフォルダを1段追加
-    // → /testApp/[user]/[id]/home/page.tsx
+    // After modification: insert dynamic folder [id]
     mock.restore();
     mock({
       "/testApp": {
@@ -793,7 +825,6 @@ describe("scanAppDirCache dynamic folder scenarios - detailed verification", () 
         },
       },
     });
-    // 追加された部分のキャッシュをクリア（※子ディレクトリのキャッシュを削除すれば上位も再生成される）
     clearScanAppDirCache("/testApp/[user]/[id]");
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
@@ -807,7 +838,7 @@ describe("scanAppDirCache dynamic folder scenarios - detailed verification", () 
   });
 
   it("should generate correct output when multiple dynamic folders are added in between", () => {
-    // 初期状態: /testApp/[user]/home/page.tsx
+    // Initial: /testApp/[user]/home/page.tsx
     mock({
       "/testApp": {
         "[user]": {
@@ -825,8 +856,7 @@ describe("scanAppDirCache dynamic folder scenarios - detailed verification", () 
 }`;
     expect(initial.pathStructure).toBe(expectedInitial);
 
-    // 変更後: 複数のダイナミックフォルダを挿入
-    // → /testApp/[user]/[id]/[detail]/home/page.tsx
+    // After modification: insert [id] and [detail] in between
     mock.restore();
     mock({
       "/testApp": {
@@ -855,8 +885,8 @@ describe("scanAppDirCache dynamic folder scenarios - detailed verification", () 
     expect(modified.pathStructure).toBe(expectedModified);
   });
 
-  it("should generate correct output when a dynamic folder is inserted in the middle of an already multi-folder dynamic structure", () => {
-    // 初期状態: /testApp/[user]/[id]/home/page.tsx
+  it("should generate correct output when a dynamic folder is inserted in the middle of an existing dynamic structure", () => {
+    // Initial: /testApp/[user]/[id]/home/page.tsx
     mock({
       "/testApp": {
         "[user]": {
@@ -878,8 +908,7 @@ describe("scanAppDirCache dynamic folder scenarios - detailed verification", () 
 }`;
     expect(initial.pathStructure).toBe(expectedInitial);
 
-    // 変更後: 既存の2段階の間にもう1段階挿入
-    // → /testApp/[user]/[lang]/[id]/home/page.tsx
+    // After modification: insert [lang] between [user] and [id]
     mock.restore();
     mock({
       "/testApp": {
@@ -909,22 +938,23 @@ describe("scanAppDirCache dynamic folder scenarios - detailed verification", () 
   });
 });
 
+// ----------------------
+// Test for scanAppDirCache multiple child directories scenarios
+// ----------------------
 describe("scanAppDirCache multiple child directories scenarios", () => {
   beforeEach(() => {
+    // Clear caches before each test
     scanAppDirCache.clear();
     visitedDirsCache.clear();
     clearCntCache();
   });
 
   afterEach(() => {
+    // Restore the mock file system
     mock.restore();
   });
 
   it("should generate correct output when multiple child directories exist and one branch is modified with an additional dynamic folder", () => {
-    // 初期状態:
-    // /testApp
-    //   [user]/home/page.tsx   → dynamic: "[user]" → "_user" として処理される
-    //   static/home/page.tsx     → 静的ディレクトリ "static"
     mock({
       "/testApp": {
         "[user]": {
@@ -944,8 +974,9 @@ describe("scanAppDirCache multiple child directories scenarios", () => {
         },
       },
     });
+
     const initial = scanAppDir("/output", "/testApp");
-    // sorted順はファイルシステムのデフォルトの lexicographical ソートに従い、"[user]" は _user、"static" はそのまま "static"
+    // Sorted by lexicographical order
     const expectedInitial = `{
   "_admin": {
     "home": Endpoint & Record<ParamsKey, { "admin": string }>
@@ -959,10 +990,7 @@ describe("scanAppDirCache multiple child directories scenarios", () => {
 }`;
     expect(initial.pathStructure).toBe(expectedInitial);
 
-    // 変更後: [user] ブランチに動的フォルダ [id] を追加して
-    // /testApp
-    //   [user]/[id]/home/page.tsx   → _user/_id の階層に変化
-    //   static/home/page.tsx         → 変更なし
+    // After modification: add dynamic folder [id] under both branches
     mock.restore();
     mock({
       "/testApp": {
@@ -987,9 +1015,11 @@ describe("scanAppDirCache multiple child directories scenarios", () => {
         },
       },
     });
-    // 追加された動的フォルダのパスを指定してキャッシュクリア
+
+    // Clear caches for added dynamic folders
     clearScanAppDirCache("/testApp/[admin]/[id]");
     clearScanAppDirCache("/testApp/[user]/[id]");
+
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
   "_admin": {
@@ -1010,11 +1040,6 @@ describe("scanAppDirCache multiple child directories scenarios", () => {
   });
 
   it("should generate correct output when multiple child directories exist and both branches are modified with additional dynamic folders", () => {
-    // 初期状態:
-    // /testApp
-    //   [user]/home/page.tsx      → _user
-    //   [group]/dashboard/page.tsx → _group
-    // ※ 両方とも動的フォルダのため、各ブランチは Record<ParamsKey, …> が付与される
     mock({
       "/testApp": {
         "[user]": {
@@ -1029,8 +1054,9 @@ describe("scanAppDirCache multiple child directories scenarios", () => {
         },
       },
     });
+
     const initial = scanAppDir("/output", "/testApp");
-    // ソート順："[group]" が先、"[user]" が後になる想定
+    // Sorting: "[group]" comes before "[user]"
     const expectedInitial = `{
   "_group": {
     "dashboard": Endpoint & Record<ParamsKey, { "group": string }>
@@ -1041,10 +1067,7 @@ describe("scanAppDirCache multiple child directories scenarios", () => {
 }`;
     expect(initial.pathStructure).toBe(expectedInitial);
 
-    // 変更後: 両ブランチに追加の動的フォルダ [id] を挿入
-    // /testApp
-    //   [user]/[id]/home/page.tsx      → _user/_id
-    //   [group]/[id]/dashboard/page.tsx  → _group/_id
+    // After modification: insert additional dynamic folder [id] into both branches
     mock.restore();
     mock({
       "/testApp": {
@@ -1064,9 +1087,11 @@ describe("scanAppDirCache multiple child directories scenarios", () => {
         },
       },
     });
-    // キャッシュクリア：両方の追加されたパスをクリアすれば上位も再生成される
+
+    // Clear caches for added dynamic folders
     clearScanAppDirCache("/testApp/[user]/[id]");
     clearScanAppDirCache("/testApp/[group]/[id]");
+
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
   "_group": {

--- a/src/cli/core/route-scanner.test.ts
+++ b/src/cli/core/route-scanner.test.ts
@@ -1,12 +1,15 @@
 import mock from "mock-fs";
-import { describe, beforeEach, afterEach, it, expect } from "vitest";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 import {
-  clearCntCache,
   clearScanAppDirCacheAbove,
   scanAppDirCache,
   visitedDirsCache,
 } from "./cache";
 import { hasTargetFiles, scanAppDir } from "./route-scanner";
+
+vi.mock("./alias", () => ({
+  createImportAlias: vi.fn((path: string, name: string) => `${name}_asmocked`),
+}));
 
 // ----------------------
 // Test for hasTargetFiles
@@ -135,7 +138,7 @@ describe("scanAppDir", () => {
     const expectPathStructure = `{
   "api": {
     "users": {
-      "_id": { "$get": typeof GET_0 } & { "$head": typeof HEAD_0 } & { "$post": typeof POST_0 } & { "$put": typeof PUT_0 } & { "$delete": typeof DELETE_0 } & { "$patch": typeof PATCH_0 } & Endpoint & Record<ParamsKey, { "id": string }>
+      "_id": { "$get": typeof GET_asmocked } & { "$head": typeof HEAD_asmocked } & { "$post": typeof POST_asmocked } & { "$put": typeof PUT_asmocked } & { "$delete": typeof DELETE_asmocked } & { "$patch": typeof PATCH_asmocked } & Endpoint & Record<ParamsKey, { "id": string }>
     }
   }
 }`;
@@ -152,32 +155,32 @@ describe("scanAppDir", () => {
     const expectedImports = [
       {
         statement:
-          'import type { GET as GET_0 } from "./testApp/api/users/[id]/route";',
+          'import type { GET as GET_asmocked } from "./testApp/api/users/[id]/route";',
         method: "GET",
       },
       {
         statement:
-          'import type { HEAD as HEAD_0 } from "./testApp/api/users/[id]/route";',
+          'import type { HEAD as HEAD_asmocked } from "./testApp/api/users/[id]/route";',
         method: "HEAD",
       },
       {
         statement:
-          'import type { POST as POST_0 } from "./testApp/api/users/[id]/route";',
+          'import type { POST as POST_asmocked } from "./testApp/api/users/[id]/route";',
         method: "POST",
       },
       {
         statement:
-          'import type { PUT as PUT_0 } from "./testApp/api/users/[id]/route";',
+          'import type { PUT as PUT_asmocked } from "./testApp/api/users/[id]/route";',
         method: "PUT",
       },
       {
         statement:
-          'import type { DELETE as DELETE_0 } from "./testApp/api/users/[id]/route";',
+          'import type { DELETE as DELETE_asmocked } from "./testApp/api/users/[id]/route";',
         method: "DELETE",
       },
       {
         statement:
-          'import type { PATCH as PATCH_0 } from "./testApp/api/users/[id]/route";',
+          'import type { PATCH as PATCH_asmocked } from "./testApp/api/users/[id]/route";',
         method: "PATCH",
       },
     ];
@@ -245,7 +248,7 @@ describe("scanAppDir", () => {
 
     const expectPathStructure = `{
   "query": {
-    "home": Record<QueryKey, Query_0> & Endpoint
+    "home": Record<QueryKey, Query_asmocked> & Endpoint
   }
 }`;
     const { pathStructure } = scanAppDir("/output", "/testApp");
@@ -574,7 +577,6 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
     // Clear all caches before each test
     scanAppDirCache.clear();
     visitedDirsCache.clear();
-    clearCntCache();
   });
 
   afterEach(() => {
@@ -608,7 +610,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
     clearScanAppDirCacheAbove("/testApp/sub/page.tsx");
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
-  "sub": { "$get": typeof GET_0 } & Endpoint
+  "sub": { "$get": typeof GET_asmocked } & Endpoint
 }`;
     expect(modified.pathStructure).toBe(expectedModified);
   });
@@ -640,7 +642,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
     clearScanAppDirCacheAbove("/testApp/mid/page.tsx");
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
-  "mid": { "$get": typeof GET_0 } & Endpoint
+  "mid": { "$get": typeof GET_asmocked } & Endpoint
 }`;
     expect(modified.pathStructure).toBe(expectedModified);
   });
@@ -665,7 +667,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
     });
     clearScanAppDirCacheAbove("/testApp/index.ts");
     const modified = scanAppDir("/output", "/testApp");
-    const expectedModified = `{ "$get": typeof GET_0 } & Endpoint`;
+    const expectedModified = `{ "$get": typeof GET_asmocked } & Endpoint`;
     expect(modified.pathStructure).toBe(expectedModified);
   });
   it("should generate correct output when a folder is added in the lowest-level directory", () => {
@@ -786,7 +788,6 @@ describe("scanAppDirCache dynamic folder scenarios - detailed verification", () 
   beforeEach(() => {
     scanAppDirCache.clear();
     visitedDirsCache.clear();
-    clearCntCache();
   });
 
   afterEach(() => {
@@ -946,7 +947,6 @@ describe("scanAppDirCache multiple child directories scenarios", () => {
     // Clear caches before each test
     scanAppDirCache.clear();
     visitedDirsCache.clear();
-    clearCntCache();
   });
 
   afterEach(() => {

--- a/src/cli/core/route-scanner.test.ts
+++ b/src/cli/core/route-scanner.test.ts
@@ -2,7 +2,7 @@ import mock from "mock-fs";
 import { describe, beforeEach, afterEach, it, expect } from "vitest";
 import {
   clearCntCache,
-  clearScanAppDirCache,
+  clearScanAppDirCacheAbove,
   scanAppDirCache,
   visitedDirsCache,
 } from "./cache";
@@ -514,7 +514,7 @@ describe("scanAppDirCache", () => {
     });
 
     const result1 = scanAppDir("/output", "/testApp");
-    clearScanAppDirCache("/testApp");
+    clearScanAppDirCacheAbove("/testApp");
     const result2 = scanAppDir("/output", "/testApp");
     expect(result1).not.toBe(result2);
   });
@@ -533,7 +533,7 @@ describe("scanAppDirCache", () => {
     const parentResult1 = scanAppDir("/output", "/testApp");
     const childResult1 = scanAppDir("/output", "/testApp/sub");
 
-    clearScanAppDirCache("/testApp/sub");
+    clearScanAppDirCacheAbove("/testApp/sub");
 
     const parentResult2 = scanAppDir("/output", "/testApp");
     const childResult2 = scanAppDir("/output", "/testApp/sub");
@@ -556,7 +556,7 @@ describe("scanAppDirCache", () => {
     const resultTestApp1 = scanAppDir("/output", "/testApp");
     const resultAnother1 = scanAppDir("/output", "/another");
 
-    clearScanAppDirCache("/nonexistent");
+    clearScanAppDirCacheAbove("/nonexistent");
 
     const resultTestApp2 = scanAppDir("/output", "/testApp");
     const resultAnother2 = scanAppDir("/output", "/another");
@@ -605,7 +605,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
         },
       },
     });
-    clearScanAppDirCache("/testApp/sub/page.tsx");
+    clearScanAppDirCacheAbove("/testApp/sub/page.tsx");
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
   "sub": { "$get": typeof GET_0 } & Endpoint
@@ -637,7 +637,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
         },
       },
     });
-    clearScanAppDirCache("/testApp/mid/page.tsx");
+    clearScanAppDirCacheAbove("/testApp/mid/page.tsx");
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
   "mid": { "$get": typeof GET_0 } & Endpoint
@@ -663,7 +663,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
         "route.ts": "export function GET() {};",
       },
     });
-    clearScanAppDirCache("/testApp/index.ts");
+    clearScanAppDirCacheAbove("/testApp/index.ts");
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{ "$get": typeof GET_0 } & Endpoint`;
     expect(modified.pathStructure).toBe(expectedModified);
@@ -695,7 +695,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
         },
       },
     });
-    clearScanAppDirCache("/testApp/sub/newFolder");
+    clearScanAppDirCacheAbove("/testApp/sub/newFolder");
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
   "sub": Endpoint & {
@@ -738,7 +738,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
         },
       },
     });
-    clearScanAppDirCache("/testApp/mid/newFolder");
+    clearScanAppDirCacheAbove("/testApp/mid/newFolder");
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
   "mid": {
@@ -770,7 +770,7 @@ describe("scanAppDirCache modification scenarios - detailed verification", () =>
         },
       },
     });
-    clearScanAppDirCache("/testApp/newFolder");
+    clearScanAppDirCacheAbove("/testApp/newFolder");
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `Endpoint & {
   "newFolder": Endpoint
@@ -825,7 +825,7 @@ describe("scanAppDirCache dynamic folder scenarios - detailed verification", () 
         },
       },
     });
-    clearScanAppDirCache("/testApp/[user]/[id]");
+    clearScanAppDirCacheAbove("/testApp/[user]/[id]");
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
   "_user": {
@@ -871,7 +871,7 @@ describe("scanAppDirCache dynamic folder scenarios - detailed verification", () 
         },
       },
     });
-    clearScanAppDirCache("/testApp/[user]/[id]");
+    clearScanAppDirCacheAbove("/testApp/[user]/[id]");
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
   "_user": {
@@ -923,7 +923,7 @@ describe("scanAppDirCache dynamic folder scenarios - detailed verification", () 
         },
       },
     });
-    clearScanAppDirCache("/testApp/[user]/[lang]");
+    clearScanAppDirCacheAbove("/testApp/[user]/[lang]");
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
   "_user": {
@@ -1017,8 +1017,8 @@ describe("scanAppDirCache multiple child directories scenarios", () => {
     });
 
     // Clear caches for added dynamic folders
-    clearScanAppDirCache("/testApp/[admin]/[id]");
-    clearScanAppDirCache("/testApp/[user]/[id]");
+    clearScanAppDirCacheAbove("/testApp/[admin]/[id]");
+    clearScanAppDirCacheAbove("/testApp/[user]/[id]");
 
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{
@@ -1089,8 +1089,8 @@ describe("scanAppDirCache multiple child directories scenarios", () => {
     });
 
     // Clear caches for added dynamic folders
-    clearScanAppDirCache("/testApp/[user]/[id]");
-    clearScanAppDirCache("/testApp/[group]/[id]");
+    clearScanAppDirCacheAbove("/testApp/[user]/[id]");
+    clearScanAppDirCacheAbove("/testApp/[group]/[id]");
 
     const modified = scanAppDir("/output", "/testApp");
     const expectedModified = `{

--- a/src/cli/core/scan-utils.test.ts
+++ b/src/cli/core/scan-utils.test.ts
@@ -25,12 +25,12 @@ describe("scanQuery", () => {
 
     const result = scanQuery("output.ts", "input.ts");
     expect(result).toBeDefined();
-    expect(result?.importName).toBe("Query_0");
+    expect(result?.importName).toBe("Query_da299b9577978fcd");
     expect(result?.importPath).toBe("./input");
     expect(result?.importStatement).toBe(
-      "import type { Query as Query_0 } from './input';"
+      "import type { Query as Query_da299b9577978fcd } from './input';"
     );
-    expect(result?.type).toBe("Record<QueryKey, Query_0>");
+    expect(result?.type).toBe("Record<QueryKey, Query_da299b9577978fcd>");
   });
 
   it("should return a query definition for an exported type alias", () => {
@@ -40,12 +40,14 @@ describe("scanQuery", () => {
 
     const result = scanQuery("output.ts", "input.ts");
     expect(result).toBeDefined();
-    expect(result?.importName).toBe("OptionalQuery_0");
+    expect(result?.importName).toBe("OptionalQuery_d6b34eab427491f5");
     expect(result?.importPath).toBe("./input");
     expect(result?.importStatement).toBe(
-      "import type { OptionalQuery as OptionalQuery_0 } from './input';"
+      "import type { OptionalQuery as OptionalQuery_d6b34eab427491f5 } from './input';"
     );
-    expect(result?.type).toBe("Record<OptionalQueryKey, OptionalQuery_0>");
+    expect(result?.type).toBe(
+      "Record<OptionalQueryKey, OptionalQuery_d6b34eab427491f5>"
+    );
   });
 
   it("should return undefined when no relevant query definition exists", () => {
@@ -67,12 +69,12 @@ describe("scanRoute", () => {
 
     const result = scanRoute("output.ts", "input.ts", "GET");
     expect(result).toBeDefined();
-    expect(result?.importName).toBe("GET_0");
+    expect(result?.importName).toBe("GET_84a33c1aab9019d2");
     expect(result?.importPath).toBe("./input");
     expect(result?.importStatement).toBe(
-      "import type { GET as GET_0 } from './input';"
+      "import type { GET as GET_84a33c1aab9019d2 } from './input';"
     );
-    expect(result?.type).toBe('{ "$get": typeof GET_0 }');
+    expect(result?.type).toBe('{ "$get": typeof GET_84a33c1aab9019d2 }');
   });
 
   it("should return a route definition for an exported constant function", () => {
@@ -82,12 +84,12 @@ describe("scanRoute", () => {
 
     const result = scanRoute("output.ts", "input.ts", "PATCH");
     expect(result).toBeDefined();
-    expect(result?.importName).toBe("PATCH_0");
+    expect(result?.importName).toBe("PATCH_2fb9d0ae6e8b8cfc");
     expect(result?.importPath).toBe("./input");
     expect(result?.importStatement).toBe(
-      "import type { PATCH as PATCH_0 } from './input';"
+      "import type { PATCH as PATCH_2fb9d0ae6e8b8cfc } from './input';"
     );
-    expect(result?.type).toBe('{ "$patch": typeof PATCH_0 }');
+    expect(result?.type).toBe('{ "$patch": typeof PATCH_2fb9d0ae6e8b8cfc }');
   });
 
   it("should return a route definition for a destructured export", () => {
@@ -98,12 +100,12 @@ describe("scanRoute", () => {
 
     const result = scanRoute("output.ts", "input.ts", "POST");
     expect(result).toBeDefined();
-    expect(result?.importName).toBe("POST_0");
+    expect(result?.importName).toBe("POST_8393a35405bb7d7f");
     expect(result?.importPath).toBe("./input");
     expect(result?.importStatement).toBe(
-      "import type { POST as POST_0 } from './input';"
+      "import type { POST as POST_8393a35405bb7d7f } from './input';"
     );
-    expect(result?.type).toBe('{ "$post": typeof POST_0 }');
+    expect(result?.type).toBe('{ "$post": typeof POST_8393a35405bb7d7f }');
   });
 
   it("should return a route definition for a re-exported function", () => {
@@ -113,12 +115,12 @@ describe("scanRoute", () => {
 
     const result = scanRoute("output.ts", "input.ts", "DELETE");
     expect(result).toBeDefined();
-    expect(result?.importName).toBe("DELETE_0");
+    expect(result?.importName).toBe("DELETE_bacf7eb8c865f8b9");
     expect(result?.importPath).toBe("./input");
     expect(result?.importStatement).toBe(
-      "import type { DELETE as DELETE_0 } from './input';"
+      "import type { DELETE as DELETE_bacf7eb8c865f8b9 } from './input';"
     );
-    expect(result?.type).toBe('{ "$delete": typeof DELETE_0 }');
+    expect(result?.type).toBe('{ "$delete": typeof DELETE_bacf7eb8c865f8b9 }');
   });
 
   it("should increment alias count for multiple imports of the same route", () => {
@@ -128,21 +130,21 @@ describe("scanRoute", () => {
 
     const result = scanRoute("output.ts", "input.ts", "PUT");
     expect(result).toBeDefined();
-    expect(result?.importName).toBe("PUT_0");
+    expect(result?.importName).toBe("PUT_203d1825e2307ab2");
     expect(result?.importPath).toBe("./input");
     expect(result?.importStatement).toBe(
-      "import type { PUT as PUT_0 } from './input';"
+      "import type { PUT as PUT_203d1825e2307ab2 } from './input';"
     );
-    expect(result?.type).toBe('{ "$put": typeof PUT_0 }');
+    expect(result?.type).toBe('{ "$put": typeof PUT_203d1825e2307ab2 }');
 
     const result2 = scanRoute("output.ts", "input.ts", "PUT");
     expect(result2).toBeDefined();
-    expect(result2?.importName).toBe("PUT_1");
+    expect(result2?.importName).toBe("PUT_203d1825e2307ab2");
     expect(result2?.importPath).toBe("./input");
     expect(result2?.importStatement).toBe(
-      "import type { PUT as PUT_1 } from './input';"
+      "import type { PUT as PUT_203d1825e2307ab2 } from './input';"
     );
-    expect(result2?.type).toBe('{ "$put": typeof PUT_1 }');
+    expect(result2?.type).toBe('{ "$put": typeof PUT_203d1825e2307ab2 }');
   });
 
   it("should return undefined when no matching route definition exists", () => {

--- a/src/cli/core/scan-utils.ts
+++ b/src/cli/core/scan-utils.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { cntCache } from "./cache";
+import { createImportAlias } from "./alias";
 import {
   QUERY_TYPES,
   TYPE_KEY_QUERY,
@@ -8,15 +8,6 @@ import {
 import { createRelativeImportPath } from "./path-utils";
 import { createImport, createRecodeType, createObjectType } from "./type-utils";
 import { HttpMethod } from "../../lib/types";
-
-// 連番付与
-export const createImportAlias = (type: string, key: string) => {
-  if (!cntCache[key]) {
-    cntCache[key] = 0;
-  }
-
-  return `${type}_${cntCache[key]++}`;
-};
 
 export const scanFile = <T extends string | undefined>(
   outputFile: string,
@@ -32,7 +23,7 @@ export const scanFile = <T extends string | undefined>(
 
   const relativeImportPath = createRelativeImportPath(outputFile, inputFile);
 
-  const importAlias = createImportAlias(type, type);
+  const importAlias = createImportAlias(relativeImportPath, type);
 
   return {
     importName: importAlias,

--- a/src/cli/watcher.test.ts
+++ b/src/cli/watcher.test.ts
@@ -67,7 +67,6 @@ describe("setupWatcher", () => {
     expect(cacheModule.clearScanAppDirCacheAbove).toHaveBeenCalledWith(
       "/base/dir/foo/page.tsx"
     );
-    expect(cacheModule.clearCntCache).toHaveBeenCalled();
     expect(onGenerate).toHaveBeenCalled();
   });
 
@@ -93,7 +92,6 @@ describe("setupWatcher", () => {
     );
     expect(cacheModule.clearVisitedDirsCacheAbove).not.toHaveBeenCalled();
     expect(cacheModule.clearScanAppDirCacheAbove).not.toHaveBeenCalled();
-    expect(cacheModule.clearCntCache).not.toHaveBeenCalled();
     expect(onGenerate).not.toHaveBeenCalled();
   });
 
@@ -134,7 +132,6 @@ describe("setupWatcher", () => {
       "/base/dir/bar/route.ts"
     );
 
-    expect(cacheModule.clearCntCache).toHaveBeenCalled();
     expect(onGenerate).toHaveBeenCalled();
   });
 });

--- a/src/cli/watcher.test.ts
+++ b/src/cli/watcher.test.ts
@@ -7,6 +7,7 @@ import { setupWatcher } from "./watcher";
 vi.mock("./core/cache", () => ({
   clearCntCache: vi.fn(),
   clearVisitedDirsCacheAbove: vi.fn(),
+  clearScanAppDirCacheAbove: vi.fn(),
 }));
 
 vi.spyOn(debounceModule, "debounce").mockImplementation((fn) => fn);
@@ -63,6 +64,9 @@ describe("setupWatcher", () => {
     expect(cacheModule.clearVisitedDirsCacheAbove).toHaveBeenCalledWith(
       "/base/dir/foo/page.tsx"
     );
+    expect(cacheModule.clearScanAppDirCacheAbove).toHaveBeenCalledWith(
+      "/base/dir/foo/page.tsx"
+    );
     expect(cacheModule.clearCntCache).toHaveBeenCalled();
     expect(onGenerate).toHaveBeenCalled();
   });
@@ -88,6 +92,7 @@ describe("setupWatcher", () => {
       "[change] /base/dir/foo/other.txt"
     );
     expect(cacheModule.clearVisitedDirsCacheAbove).not.toHaveBeenCalled();
+    expect(cacheModule.clearScanAppDirCacheAbove).not.toHaveBeenCalled();
     expect(cacheModule.clearCntCache).not.toHaveBeenCalled();
     expect(onGenerate).not.toHaveBeenCalled();
   });
@@ -119,7 +124,13 @@ describe("setupWatcher", () => {
     expect(cacheModule.clearVisitedDirsCacheAbove).toHaveBeenCalledWith(
       "/base/dir/foo/page.tsx"
     );
+    expect(cacheModule.clearScanAppDirCacheAbove).toHaveBeenCalledWith(
+      "/base/dir/foo/page.tsx"
+    );
     expect(cacheModule.clearVisitedDirsCacheAbove).toHaveBeenCalledWith(
+      "/base/dir/bar/route.ts"
+    );
+    expect(cacheModule.clearScanAppDirCacheAbove).toHaveBeenCalledWith(
       "/base/dir/bar/route.ts"
     );
 

--- a/src/cli/watcher.ts
+++ b/src/cli/watcher.ts
@@ -1,6 +1,5 @@
 import chokidar from "chokidar";
 import {
-  clearCntCache,
   clearScanAppDirCacheAbove,
   clearVisitedDirsCacheAbove,
 } from "./core/cache";
@@ -28,7 +27,6 @@ export const setupWatcher = (
       clearScanAppDirCacheAbove(path);
     });
     changedPaths.clear();
-    clearCntCache();
 
     onGenerate();
   }, 300);

--- a/src/cli/watcher.ts
+++ b/src/cli/watcher.ts
@@ -1,5 +1,9 @@
 import chokidar from "chokidar";
-import { clearCntCache, clearVisitedDirsCacheAbove } from "./core/cache";
+import {
+  clearCntCache,
+  clearScanAppDirCacheAbove,
+  clearVisitedDirsCacheAbove,
+} from "./core/cache";
 import { debounce } from "./debounce";
 import { Logger } from "./types";
 
@@ -21,6 +25,7 @@ export const setupWatcher = (
   const debouncedGenerate = debounce(() => {
     changedPaths.forEach((path) => {
       clearVisitedDirsCacheAbove(path);
+      clearScanAppDirCacheAbove(path);
     });
     changedPaths.clear();
     clearCntCache();


### PR DESCRIPTION
## 📝 Overview

- Introduced `scanAppDirCache` to optimize route scanning performance
- Refactored cache clearing logic by consolidating it into `clearCacheAbove`
- Improved test readability by adding English comments and clearer descriptions
- Updated watcher behavior to clear cache when changes are detected
- Replaced incremental import aliasing with stable hash-based aliasing

## 😮 Motivation and Background

- Route scanning was inefficient due to redundant directory reads
- Cache clearing logic was duplicated and needed unification for maintainability
- Test comments were partially in Japanese and unclear
- Watcher needed better integration with cache updates
- Incremental aliasing caused instability; hash-based aliasing is more reliable

## ✅ Changes

- [x] Feature added
- [ ] Bug fixed
- [x] Refactored
- [ ] Documentation updated

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed

