### PR TITLE
feat: add debounceOnceRunningWithTrailing to support trailing execution after async run

### DIFF
--- a/src/cli/debounce.test.ts
+++ b/src/cli/debounce.test.ts
@@ -1,36 +1,86 @@
 import { describe, it, expect, vi } from "vitest";
-import { debounce } from "./debounce";
+import { debounceOnceRunningWithTrailing } from "./debounce";
 
-describe("debounce", () => {
-  it("should call the callback after the specified delay", () => {
+describe("debounceOnceRunningWithTrailing", () => {
+  it("should call the callback after the specified delay", async () => {
     vi.useFakeTimers();
     const callback = vi.fn();
-    const debounced = debounce(callback, 500);
+    const debounced = debounceOnceRunningWithTrailing(callback, 500);
 
     debounced("test");
     expect(callback).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(500);
+    await vi.runAllTicks(); // for async handling
+
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback).toHaveBeenCalledWith("test");
 
     vi.useRealTimers();
   });
 
-  it("should reset the delay if called repeatedly", () => {
+  it("should reset the delay if called repeatedly", async () => {
     vi.useFakeTimers();
     const callback = vi.fn();
-    const debounced = debounce(callback, 300);
+    const debounced = debounceOnceRunningWithTrailing(callback, 300);
 
     debounced("first");
     vi.advanceTimersByTime(150);
     debounced("second");
     vi.advanceTimersByTime(150);
     debounced("third");
-    vi.advanceTimersByTime(300);
+
+    vi.advanceTimersByTime(300); // final delay passes
+    await vi.runAllTicks();
 
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback).toHaveBeenCalledWith("third");
+
+    vi.useRealTimers();
+  });
+
+  it("should not run again while callback is running, but should run once after it finishes", async () => {
+    vi.useFakeTimers();
+
+    const callback = vi.fn(async (_msg: string) => {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    });
+
+    const debounced = debounceOnceRunningWithTrailing(callback, 300);
+
+    debounced("A");
+    vi.advanceTimersByTime(300); // triggers execution of "A"
+    await vi.runAllTicks(); // enters async callback
+
+    debounced("B"); // should be stored as pending
+    debounced("C"); // overwrites B
+
+    // still running, so nothing should be triggered yet
+    vi.advanceTimersByTime(1000); // callback resolves
+    await vi.runAllTicks();
+
+    // pending "C" should now run
+    await vi.advanceTimersByTimeAsync(300); // trigger pending
+    await vi.runAllTicks();
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback.mock.calls[0][0]).toBe("A");
+    expect(callback.mock.calls[1][0]).toBe("C");
+
+    vi.useRealTimers();
+  });
+
+  it("should handle no-argument case correctly", async () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    const debounced = debounceOnceRunningWithTrailing(callback, 400);
+
+    debounced(); // no arguments
+    vi.advanceTimersByTime(400);
+    await vi.runAllTicks();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith();
 
     vi.useRealTimers();
   });

--- a/src/cli/debounce.ts
+++ b/src/cli/debounce.ts
@@ -1,14 +1,40 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const debounce = <T extends (...args: any[]) => void>(
+export const debounceOnceRunningWithTrailing = <
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends (...args: any[]) => Promise<void> | void,
+>(
   func: T,
   delay: number
 ) => {
-  let timer: ReturnType<typeof setTimeout>;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let isRunning = false;
+  let pendingArgs: Parameters<T> | null = null;
+
+  const execute = async (...args: Parameters<T>) => {
+    isRunning = true;
+    try {
+      await func(...args);
+    } finally {
+      isRunning = false;
+
+      if (pendingArgs) {
+        const nextArgs = pendingArgs;
+        pendingArgs = null;
+        execute(...nextArgs);
+      }
+    }
+  };
 
   return (...args: Parameters<T>) => {
-    clearTimeout(timer);
+    if (timer) clearTimeout(timer);
+
     timer = setTimeout(() => {
-      func(...args);
+      if (isRunning) {
+        pendingArgs = args ?? [];
+
+        return;
+      }
+
+      execute(...(args ?? []));
     }, delay);
   };
 };

--- a/src/cli/watcher.test.ts
+++ b/src/cli/watcher.test.ts
@@ -10,7 +10,9 @@ vi.mock("./core/cache", () => ({
   clearScanAppDirCacheAbove: vi.fn(),
 }));
 
-vi.spyOn(debounceModule, "debounce").mockImplementation((fn) => fn);
+vi.spyOn(debounceModule, "debounceOnceRunningWithTrailing").mockImplementation(
+  (fn) => fn
+);
 
 const logger = {
   info: vi.fn(),

--- a/src/cli/watcher.ts
+++ b/src/cli/watcher.ts
@@ -3,7 +3,7 @@ import {
   clearScanAppDirCacheAbove,
   clearVisitedDirsCacheAbove,
 } from "./core/cache";
-import { debounce } from "./debounce";
+import { debounceOnceRunningWithTrailing } from "./debounce";
 import { Logger } from "./types";
 
 export const setupWatcher = (
@@ -21,7 +21,7 @@ export const setupWatcher = (
   // Once the debounced function starts executing, no new watcher events will be processed until it completes.
   // This is due to JavaScript's single-threaded event loop: the current debounced function runs to completion,
   // and any new change events are queued until the execution finishes.
-  const debouncedGenerate = debounce(() => {
+  const debouncedGenerate = debounceOnceRunningWithTrailing(() => {
     changedPaths.forEach((path) => {
       clearVisitedDirsCacheAbove(path);
       clearScanAppDirCacheAbove(path);


### PR DESCRIPTION
## 📝 Overview

- Introduced `debounceOnceRunningWithTrailing`, a new debounce utility that ensures:
  - Only one callback runs at a time
  - A trailing call is queued and executed after the current one completes
  - Works with async functions
- Replaced existing `debounce` usage in `watcher.ts` with the new implementation
- Added thorough unit tests for various usage patterns

## 😨 Motivation and Background

- The previous debounce implementation did not handle async callbacks properly, which could lead to dropped or overlapping executions.
- This update ensures trailing executions are reliably queued even while the first async task is still in progress.

## ✅ Changes

- [x] Feature added: `debounceOnceRunningWithTrailing`
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- Replaced the debounce spy in tests to match the new function
- All tests still pass and cover async behavior, argument forwarding, and edge cases (e.g., no args)

## 🗐 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed

