### PR TITLE
update: delay initial generate call until after watcher is ready

### DIFF
--- a/src/cli/cli-handler.test.ts
+++ b/src/cli/cli-handler.test.ts
@@ -57,7 +57,7 @@ describe("handleCli", () => {
     const result = handleCli(baseDir, outputPath, options, logger);
 
     expect(result).toBe(0);
-    expect(generatorModule.generate).toHaveBeenCalledTimes(1);
+    expect(generatorModule.generate).toHaveBeenCalledTimes(0);
     expect(watcherModule.setupWatcher).toHaveBeenCalledWith(
       expect.stringContaining("/testDir"),
       expect.any(Function),
@@ -68,7 +68,7 @@ describe("handleCli", () => {
     const callback = mockedSetupWatcher.mock.calls[0][1];
     callback();
 
-    expect(generatorModule.generate).toHaveBeenCalledTimes(2);
+    expect(generatorModule.generate).toHaveBeenCalledTimes(1);
   });
 
   it("should work correctly when options are omitted", () => {

--- a/src/cli/cli-handler.ts
+++ b/src/cli/cli-handler.ts
@@ -21,13 +21,6 @@ export const handleCli = (
     return 1;
   }
 
-  generate({
-    baseDir: resolvedBaseDir,
-    outputPath: resolvedOutputPath,
-    paramsFileName: options.paramsFile || null,
-    logger,
-  });
-
   if (options.watch) {
     setupWatcher(
       resolvedBaseDir,
@@ -41,6 +34,13 @@ export const handleCli = (
       },
       logger
     );
+  } else {
+    generate({
+      baseDir: resolvedBaseDir,
+      outputPath: resolvedOutputPath,
+      paramsFileName: options.paramsFile || null,
+      logger,
+    });
   }
 
   return 0;

--- a/src/cli/watcher.test.ts
+++ b/src/cli/watcher.test.ts
@@ -58,7 +58,7 @@ describe("setupWatcher", () => {
       return fakeWatcher;
     });
 
-    readyHandler?.();
+    readyHandler?.(); // debouncedGenerate() runs once here
 
     allHandler?.("change", "/base/dir/foo/page.tsx");
 
@@ -69,7 +69,7 @@ describe("setupWatcher", () => {
     expect(cacheModule.clearScanAppDirCacheAbove).toHaveBeenCalledWith(
       "/base/dir/foo/page.tsx"
     );
-    expect(onGenerate).toHaveBeenCalled();
+    expect(onGenerate).toHaveBeenCalledTimes(2);
   });
 
   it("should ignore non-target files", () => {
@@ -89,12 +89,13 @@ describe("setupWatcher", () => {
 
     readyHandler?.();
 
+    // Only the initial call from ready
     expect(logger.info).not.toHaveBeenCalledWith(
       "[change] /base/dir/foo/other.txt"
     );
     expect(cacheModule.clearVisitedDirsCacheAbove).not.toHaveBeenCalled();
     expect(cacheModule.clearScanAppDirCacheAbove).not.toHaveBeenCalled();
-    expect(onGenerate).not.toHaveBeenCalled();
+    expect(onGenerate).toHaveBeenCalledTimes(1); // only from ready
   });
 
   it("should process multiple changed paths before debounce triggers", () => {
@@ -134,6 +135,6 @@ describe("setupWatcher", () => {
       "/base/dir/bar/route.ts"
     );
 
-    expect(onGenerate).toHaveBeenCalled();
+    expect(onGenerate).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/cli/watcher.ts
+++ b/src/cli/watcher.ts
@@ -38,6 +38,8 @@ export const setupWatcher = (
   });
 
   watcher.on("ready", () => {
+    // First execution
+    debouncedGenerate();
     watcher.on("all", (event, path) => {
       if (isTargetFiles(path)) {
         logger.info(`[${event}] ${path}`);


### PR DESCRIPTION
## 📝 Overview

- Moved the `generate` call inside the `setupWatcher` flow so it only runs after the watcher is ready.
- Updated related tests to reflect the new behavior and ensure correct call counts.

## 😮 Motivation and Background

- Previously, `generate` was called before the watcher was initialized, resulting in an extra, unnecessary generation step when using the `--watch` option.
- To improve performance and clarity, we changed the timing so that `generate` is only called once the watcher is ready and listening for changes.

## ✅ Changes

- [ ] Feature added
- [x] Bug fixed
- [ ] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- This change ensures that in watch mode, `generate` behaves consistently and doesn't double-run at startup.
- The test expectations have been updated accordingly to reflect accurate `generate` call counts.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed