### PR TITLE
feat: support typed JSON body handling and validation for RPC client and server

### DIFF
--- a/src/helper/client/rpc-validater.test.ts
+++ b/src/helper/client/rpc-validater.test.ts
@@ -1,0 +1,125 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+  describe,
+  it,
+  expectTypeOf,
+  afterAll,
+  afterEach,
+  beforeAll,
+  expect,
+} from "vitest";
+import { z } from "zod";
+import { ContentType, routeHandlerFactory } from "../server";
+import { createRpcClient } from "./rpc";
+import { BodyOptions, ClientOptions, Endpoint } from "./types";
+import { zodValidator } from "../server/validators/zod";
+
+const schema = z.object({
+  name: z.string(),
+  hoge: z.string(),
+});
+
+const createRouteHandler = routeHandlerFactory();
+
+const { GET: _get_1 } = createRouteHandler().get((rc) => rc.text("text"));
+
+const { POST: _post_1 } = createRouteHandler().post(
+  zodValidator("json", schema),
+  (rc) => rc.text("text")
+);
+
+const server = setupServer(
+  http.post("http://localhost:3000/api/hoge/test", async ({ request }) => {
+    const contentType = request.headers.get("Content-Type");
+    const body = await request.json();
+    const result = schema.safeParse(body);
+
+    if (!result.success) {
+      return HttpResponse.json(
+        { error: "Invalid JSON", issues: result.error.format() },
+        { status: 400 }
+      );
+    }
+
+    return HttpResponse.json({ json: result.data, contentType });
+  })
+);
+
+type PathStructure = Endpoint & {
+  api: {
+    hoge: {
+      $get: typeof _get_1;
+    } & Endpoint & {
+        _foo: { $post: typeof _post_1 } & Endpoint;
+      };
+  };
+};
+
+describe("createRpcClient", () => {
+  describe("createRpcClient basic behavior", () => {
+    // MSW lifecycle setup
+    beforeAll(() => server.listen());
+    afterEach(() => server.resetHandlers());
+    afterAll(() => server.close());
+
+    it("should send correct JSON body and receive expected response", async () => {
+      const client = createRpcClient<PathStructure>("http://localhost:3000");
+      const response = await client.api.hoge
+        ._foo("test")
+        .$post({ body: { json: { hoge: "hogehoge", name: "foo" } } });
+
+      const json = await response.json();
+      expect(json).toStrictEqual({
+        json: { hoge: "hogehoge", name: "foo" },
+        contentType: "application/json",
+      });
+    });
+  });
+});
+
+describe("createHandler type definitions", () => {
+  it("should infer types correctly", async () => {
+    const customFetch = async (_: RequestInfo | URL, __?: RequestInit) => {
+      return new Response();
+    };
+    const client = createRpcClient<PathStructure>("", {
+      fetch: customFetch,
+    });
+
+    type ExpectedNonJsonParameters = [
+      methodParam?: {
+        url?: {
+          query?: Record<string, string | number>;
+          hash?: string;
+        };
+      },
+      option?: ClientOptions<ContentType, never>,
+    ];
+
+    expectTypeOf<
+      Parameters<typeof client.api.hoge.$get>
+    >().toEqualTypeOf<ExpectedNonJsonParameters>();
+
+    type ExpectedJsonParameters = [
+      methodParam: {
+        url?: {
+          query?: Record<string, string | number>;
+          hash?: string;
+        };
+      } & {
+        body: BodyOptions<{
+          name: string;
+          hoge: string;
+        }>;
+      },
+      option?: ClientOptions<"application/json", "body">,
+    ];
+
+    const _post1 = client.api.hoge._foo("").$post;
+
+    expectTypeOf<
+      Parameters<typeof _post1>
+    >().toEqualTypeOf<ExpectedJsonParameters>();
+  });
+});

--- a/src/helper/server/types.ts
+++ b/src/helper/server/types.ts
@@ -372,7 +372,7 @@ export interface RouteContext<
   ) => TypedNextResponse<undefined, TStatus, "">;
 }
 
-export type ValidationTarget = "params" | "query";
+export type ValidationTarget = "params" | "query" | "json";
 
 type ValidationFor<
   TDirection extends keyof ValidationSchema,
@@ -382,7 +382,7 @@ type ValidationFor<
   ? TSchema[TDirection][TTarget]
   : never;
 
-type ValidationInputFor<
+export type ValidationInputFor<
   TTarget extends ValidationTarget,
   TSchema extends ValidationSchema,
 > = ValidationFor<"input", TTarget, TSchema>;

--- a/src/helper/server/validators/zod/zod-validator.ts
+++ b/src/helper/server/validators/zod/zod-validator.ts
@@ -72,6 +72,9 @@ export const zodValidator = <
       if (target === "query") {
         return rc.req.query();
       }
+      if (target === "json") {
+        return rc.req.json();
+      }
     })();
 
     const result = await schema.safeParseAsync(value);


### PR DESCRIPTION
## 📝 Overview

- Added support for `"json"` as a validation target in `zodValidator`
- Enabled schema validation of JSON bodies in route handlers
- Allowed typed `body.json` input on the client with proper type inference
- Added tests for validation and type safety

## 😮 Motivation and Background

- Needed to validate JSON request bodies using Zod
- Wanted to provide proper type inference when sending `body.json` from the client
- Improved DX and runtime safety for JSON-based API communication

## ✅ Changes

- [x] Feature added: support for `"json"` validation and typed `body.json` input
- [ ] Bug fixed
- [x] Refactored: client and validator updated to handle JSON typing
- [x] Documentation updated: tests demonstrate usage and type inference

## 💡 Notes / Screenshots

- Added type-level test cases using `expectTypeOf`
- Verified integration using MSW and typed RPC client usage

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed