### PR TITLE
feat: support header and cookie validation in client and server with type-safe integration

### DIFF
--- a/src/helper/client/rpc-validater.test.ts
+++ b/src/helper/client/rpc-validater.test.ts
@@ -10,9 +10,9 @@ import {
   expect,
 } from "vitest";
 import { z } from "zod";
-import { ContentType, routeHandlerFactory } from "../server";
+import { routeHandlerFactory } from "../server";
 import { createRpcClient } from "./rpc";
-import { BodyOptions, ClientOptions, Endpoint } from "./types";
+import { ClientOptions, Endpoint } from "./types";
 import { zodValidator } from "../server/validators/zod";
 
 const schema = z.object({
@@ -29,29 +29,34 @@ const { POST: _post_1 } = createRouteHandler().post(
   (rc) => rc.text("text")
 );
 
-const server = setupServer(
-  http.post("http://localhost:3000/api/hoge/test", async ({ request }) => {
-    const contentType = request.headers.get("Content-Type");
-    const body = await request.json();
-    const result = schema.safeParse(body);
-
-    if (!result.success) {
-      return HttpResponse.json(
-        { error: "Invalid JSON", issues: result.error.format() },
-        { status: 400 }
-      );
-    }
-
-    return HttpResponse.json({ json: result.data, contentType });
-  })
+const { POST: _post_2 } = createRouteHandler().post(
+  zodValidator("headers", schema),
+  (rc) => rc.text("text")
 );
+
+const { POST: _post_3 } = createRouteHandler().post(
+  zodValidator("cookies", schema),
+  (rc) => rc.text("text")
+);
+
+const { POST: _post_4 } = createRouteHandler().post(
+  zodValidator("json", schema),
+  zodValidator("headers", schema),
+  zodValidator("cookies", schema),
+  (rc) => rc.text("text")
+);
+
+const server = setupServer();
 
 type PathStructure = Endpoint & {
   api: {
-    hoge: {
+    none: {
       $get: typeof _get_1;
     } & Endpoint & {
-        _foo: { $post: typeof _post_1 } & Endpoint;
+        _json: { $post: typeof _post_1 } & Endpoint;
+        headers: { $post: typeof _post_2 } & Endpoint;
+        cookies: { $post: typeof _post_3 } & Endpoint;
+        all: { $post: typeof _post_4 } & Endpoint;
       };
   };
 };
@@ -64,9 +69,29 @@ describe("createRpcClient", () => {
     afterAll(() => server.close());
 
     it("should send correct JSON body and receive expected response", async () => {
+      server.use(
+        http.post(
+          "http://localhost:3000/api/none/json",
+          async ({ request }) => {
+            const contentType = request.headers.get("Content-Type");
+            const body = await request.json();
+            const result = schema.safeParse(body);
+
+            if (!result.success) {
+              return HttpResponse.json(
+                { error: "Invalid JSON", issues: result.error.format() },
+                { status: 400 }
+              );
+            }
+
+            return HttpResponse.json({ json: result.data, contentType });
+          }
+        )
+      );
+
       const client = createRpcClient<PathStructure>("http://localhost:3000");
-      const response = await client.api.hoge
-        ._foo("test")
+      const response = await client.api.none
+        ._json("json")
         .$post({ body: { json: { hoge: "hogehoge", name: "foo" } } });
 
       const json = await response.json();
@@ -74,6 +99,148 @@ describe("createRpcClient", () => {
         json: { hoge: "hogehoge", name: "foo" },
         contentType: "application/json",
       });
+    });
+  });
+});
+
+describe("Headers and Cookies validation", () => {
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  it("should validate headers correctly", async () => {
+    server.use(
+      http.post(
+        "http://localhost:3000/api/none/headers",
+        async ({ request }) => {
+          const headers = {
+            hoge: request.headers.get("hoge"),
+            name: request.headers.get("name"),
+          };
+          const result = schema.safeParse(headers);
+          if (!result.success) {
+            return HttpResponse.json(
+              { error: "Invalid headers", issues: result.error.format() },
+              { status: 400 }
+            );
+          }
+
+          return HttpResponse.json({ headers: result.data });
+        }
+      )
+    );
+
+    const client = createRpcClient<PathStructure>("http://localhost:3000");
+    const response = await client.api.none.headers.$post({
+      requestHeaders: { headers: { hoge: "hogehoge", name: "foo" } },
+    });
+    const json = await response.json();
+    expect(json).toStrictEqual({ headers: { hoge: "hogehoge", name: "foo" } });
+  });
+
+  it("should validate cookies correctly", async () => {
+    server.use(
+      http.post(
+        "http://localhost:3000/api/none/cookies",
+        async ({ request }) => {
+          const cookieHeader = request.headers.get("Cookie") || "";
+          const cookies: Record<string, string> = {};
+          cookieHeader.split(";").forEach((cookie) => {
+            const [key, value] = cookie.trim().split("=");
+            if (key && value) {
+              cookies[key] = value;
+            }
+          });
+          const result = schema.safeParse(cookies);
+          if (!result.success) {
+            return HttpResponse.json(
+              { error: "Invalid cookies", issues: result.error.format() },
+              { status: 400 }
+            );
+          }
+
+          return HttpResponse.json({ cookies: result.data });
+        }
+      )
+    );
+
+    const client = createRpcClient<PathStructure>("http://localhost:3000");
+    const response = await client.api.none.cookies.$post({
+      requestHeaders: { cookies: { hoge: "hogehoge", name: "foo" } },
+    });
+    const json = await response.json();
+    expect(json).toStrictEqual({ cookies: { hoge: "hogehoge", name: "foo" } });
+  });
+
+  it("should validate json, headers and cookies together correctly", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/none/all", async ({ request }) => {
+        const contentType = request.headers.get("Content-Type");
+        const body = await request.json().catch(() => ({}));
+        const jsonData = body;
+        const headersData = {
+          hoge: request.headers.get("hoge"),
+          name: request.headers.get("name"),
+        };
+        const cookieHeader = request.headers.get("Cookie") || "";
+        const cookiesData: Record<string, string> = {};
+        cookieHeader.split(";").forEach((cookie) => {
+          const [key, value] = cookie.trim().split("=");
+          if (key && value) {
+            cookiesData[key] = value;
+          }
+        });
+
+        const jsonResult = schema.safeParse(jsonData);
+        const headersResult = schema.safeParse(headersData);
+        const cookiesResult = schema.safeParse(cookiesData);
+        if (
+          !jsonResult.success ||
+          !headersResult.success ||
+          !cookiesResult.success
+        ) {
+          return HttpResponse.json(
+            {
+              error: "Invalid data",
+              issues: {
+                json: jsonResult.success
+                  ? undefined
+                  : jsonResult.error.format(),
+                headers: headersResult.success
+                  ? undefined
+                  : headersResult.error.format(),
+                cookies: cookiesResult.success
+                  ? undefined
+                  : cookiesResult.error.format(),
+              },
+            },
+            { status: 400 }
+          );
+        }
+
+        return HttpResponse.json({
+          json: jsonResult.data,
+          headers: headersResult.data,
+          cookies: cookiesResult.data,
+          contentType,
+        });
+      })
+    );
+
+    const client = createRpcClient<PathStructure>("http://localhost:3000");
+    const response = await client.api.none.all.$post({
+      body: { json: { hoge: "hogehoge", name: "foo" } },
+      requestHeaders: {
+        headers: { hoge: "hogehoge", name: "foo" },
+        cookies: { hoge: "hogehoge", name: "foo" },
+      },
+    });
+    const json = await response.json();
+    expect(json).toStrictEqual({
+      json: { hoge: "hogehoge", name: "foo" },
+      headers: { hoge: "hogehoge", name: "foo" },
+      cookies: { hoge: "hogehoge", name: "foo" },
+      contentType: "application/json",
     });
   });
 });
@@ -94,11 +261,11 @@ describe("createHandler type definitions", () => {
           hash?: string;
         };
       },
-      option?: ClientOptions<ContentType, never>,
+      option?: ClientOptions<never, never>,
     ];
 
     expectTypeOf<
-      Parameters<typeof client.api.hoge.$get>
+      Parameters<typeof client.api.none.$get>
     >().toEqualTypeOf<ExpectedNonJsonParameters>();
 
     type ExpectedJsonParameters = [
@@ -108,18 +275,94 @@ describe("createHandler type definitions", () => {
           hash?: string;
         };
       } & {
-        body: BodyOptions<{
-          name: string;
-          hoge: string;
-        }>;
+        body: {
+          json: {
+            name: string;
+            hoge: string;
+          };
+        };
       },
-      option?: ClientOptions<"application/json", "body">,
+      option?: ClientOptions<"Content-Type", "body">,
     ];
 
-    const _post1 = client.api.hoge._foo("").$post;
+    const _post1 = client.api.none._json("").$post;
 
     expectTypeOf<
       Parameters<typeof _post1>
     >().toEqualTypeOf<ExpectedJsonParameters>();
+
+    type ExpectedHeadersParameters = [
+      methodParam: {
+        url?: {
+          query?: Record<string, string | number>;
+          hash?: string;
+        };
+      } & {
+        requestHeaders: {
+          headers: {
+            hoge: string;
+            name: string;
+          };
+        };
+      },
+      option?: ClientOptions<never, "headers">,
+    ];
+
+    expectTypeOf<
+      Parameters<typeof client.api.none.headers.$post>
+    >().toEqualTypeOf<ExpectedHeadersParameters>();
+
+    type ExpectedCookiesParameters = [
+      methodParam: {
+        url?: {
+          query?: Record<string, string | number>;
+          hash?: string;
+        };
+      } & {
+        requestHeaders: {
+          cookies: {
+            hoge: string;
+            name: string;
+          };
+        };
+      },
+      option?: ClientOptions<"Cookie", never>,
+    ];
+
+    expectTypeOf<
+      Parameters<typeof client.api.none.cookies.$post>
+    >().toEqualTypeOf<ExpectedCookiesParameters>();
+
+    type ExpectedAllParameters = [
+      methodParam: {
+        url?: {
+          query?: Record<string, string | number>;
+          hash?: string;
+        };
+      } & {
+        body: {
+          json: {
+            name: string;
+            hoge: string;
+          };
+        };
+      } & {
+        requestHeaders: {
+          headers: {
+            hoge: string;
+            name: string;
+          };
+          cookies: {
+            hoge: string;
+            name: string;
+          };
+        };
+      },
+      option?: ClientOptions<"Cookie" | "Content-Type", "headers" | "body">,
+    ];
+
+    expectTypeOf<
+      Parameters<typeof client.api.none.all.$post>
+    >().toEqualTypeOf<ExpectedAllParameters>();
   });
 });

--- a/src/helper/server/types.ts
+++ b/src/helper/server/types.ts
@@ -372,7 +372,12 @@ export interface RouteContext<
   ) => TypedNextResponse<undefined, TStatus, "">;
 }
 
-export type ValidationTarget = "params" | "query" | "json";
+export type ValidationTarget =
+  | "params"
+  | "query"
+  | "json"
+  | "headers"
+  | "cookies";
 
 type ValidationFor<
   TDirection extends keyof ValidationSchema,

--- a/src/helper/server/validators/validator-utils.test.ts
+++ b/src/helper/server/validators/validator-utils.test.ts
@@ -1,0 +1,118 @@
+import * as headersModule from "next/headers";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getHeadersObject, getCookiesObject } from "./validator-utils";
+
+// Mock the next/headers module
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+  cookies: vi.fn(),
+}));
+
+// Helper to set up mock for headers
+const setupHeadersMock = (entries: [string, string][]) => {
+  vi.mocked(headersModule.headers).mockResolvedValue(
+    // Return an object with only entries() and cast it as Headers type
+    {
+      entries: () => entries[Symbol.iterator](),
+    } as unknown as Headers
+  );
+};
+
+// Helper to set up mock for cookies
+const setupCookiesMock = (cookies: { name: string; value: string }[]) => {
+  vi.mocked(headersModule.cookies).mockResolvedValue(
+    // Return an object with only getAll(), cast as RequestCookies & ResponseCookies type
+    {
+      getAll: () => cookies,
+    } as unknown as Awaited<ReturnType<typeof headersModule.cookies>>
+  );
+};
+
+describe("getHeadersObject – Pattern Tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const cases: Array<{
+    name: string;
+    entries: [string, string][];
+    expected: Record<string, string>;
+  }> = [
+    { name: "Empty header list", entries: [], expected: {} },
+    {
+      name: "Single header",
+      entries: [["accept", "text/html"]],
+      expected: { accept: "text/html" },
+    },
+    {
+      name: "Multiple headers",
+      entries: [
+        ["content-type", "application/json"],
+        ["x-test", "value"],
+      ],
+      expected: {
+        "content-type": "application/json",
+        "x-test": "value",
+      },
+    },
+    {
+      name: "Duplicate keys are overwritten by later value",
+      entries: [
+        ["x-dup", "first"],
+        ["x-dup", "second"],
+      ],
+      expected: { "x-dup": "second" },
+    },
+  ];
+
+  for (const { name, entries, expected } of cases) {
+    it(name, async () => {
+      setupHeadersMock(entries);
+      const result = await getHeadersObject();
+      expect(result).toEqual(expected);
+    });
+  }
+});
+
+describe("getCookiesObject – Pattern Tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const cases: Array<{
+    name: string;
+    cookies: { name: string; value: string }[];
+    expected: Record<string, string>;
+  }> = [
+    { name: "Empty cookie list", cookies: [], expected: {} },
+    {
+      name: "Single cookie",
+      cookies: [{ name: "token", value: "xyz" }],
+      expected: { token: "xyz" },
+    },
+    {
+      name: "Multiple cookies",
+      cookies: [
+        { name: "a", value: "1" },
+        { name: "b", value: "2" },
+      ],
+      expected: { a: "1", b: "2" },
+    },
+    {
+      name: "Duplicate cookie names are overwritten by later value",
+      cookies: [
+        { name: "dup", value: "first" },
+        { name: "dup", value: "second" },
+      ],
+      expected: { dup: "second" },
+    },
+  ];
+
+  for (const { name, cookies, expected } of cases) {
+    it(name, async () => {
+      setupCookiesMock(cookies);
+      const result = await getCookiesObject();
+      expect(result).toEqual(expected);
+    });
+  }
+});

--- a/src/helper/server/validators/validator-utils.ts
+++ b/src/helper/server/validators/validator-utils.ts
@@ -1,0 +1,23 @@
+import { cookies, headers } from "next/headers";
+
+export const getHeadersObject = async () => {
+  const headersList = await headers();
+  const headersObj: Record<string, string> = {};
+
+  for (const [key, value] of headersList.entries()) {
+    headersObj[key] = value;
+  }
+
+  return headersObj;
+};
+
+export const getCookiesObject = async () => {
+  const cookiesList = await cookies();
+  const cookiesObj: Record<string, string> = {};
+
+  for (const cookie of cookiesList.getAll()) {
+    cookiesObj[cookie.name] = cookie.value;
+  }
+
+  return cookiesObj;
+};

--- a/src/helper/server/validators/zod/zod-validator.ts
+++ b/src/helper/server/validators/zod/zod-validator.ts
@@ -8,6 +8,7 @@
  */
 
 import { createHandler } from "../../create-handler";
+import { getCookiesObject, getHeadersObject } from "../validator-utils";
 import type { ValidationSchema } from "../../route-types";
 import type {
   RouteContext,
@@ -74,6 +75,12 @@ export const zodValidator = <
       }
       if (target === "json") {
         return rc.req.json();
+      }
+      if (target === "headers") {
+        return await getHeadersObject();
+      }
+      if (target === "cookies") {
+        return await getCookiesObject();
       }
     })();
 


### PR DESCRIPTION
## 📝 Overview

This PR adds support for validating and sending HTTP request headers and cookies in both client and server logic. The feature enhances type safety, improves flexibility, and enables more secure and structured API interactions.

## 😮 Motivation and Background

Previously, the framework supported validation for JSON bodies, but lacked built-in handling for headers and cookies. This limited the ability to fully validate incoming request metadata or control outbound request headers in a structured way. This change addresses those limitations and unifies validation logic.

## ✅ Changes

- [x] Feature added: Support for `requestHeaders` (headers and cookies) in `httpMethod`
- [x] Feature added: Type-safe integration for headers and cookies in client request types
- [x] Feature added: Server-side `zodValidator` extended to support `"headers"` and `"cookies"` targets
- [x] Utilities added: `getHeadersObject` and `getCookiesObject` to extract metadata on the server
- [x] Tests added: Unit and integration tests covering header and cookie validation behavior
- [x] Type definitions expanded to support validation and request building for `headers` and `cookies`

## 💡 Notes / Screenshots

- All request metadata (headers and cookies) is now normalized and merged consistently in the client.
- Type inference ensures compile-time safety for developers using RPC handlers with header/cookie validation.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed
  - Validated header and cookie merging order in requests
  - Confirmed server validation responses for success and error cases

