### PR TITLE
fix: exclude current release tag from changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,10 @@ jobs:
       - name: Generate changelog
         id: changelog
         run: |
-          changelog="$(git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:"- %s")"
+          current_tag="${GITHUB_REF#refs/tags/}"
+          previous_tag=$(git tag --sort=-v:refname | grep -v "^${current_tag}$" | head -n 1)
+          echo "Found previous tag: $previous_tag"
+          changelog="$(git log ${previous_tag}^..HEAD --pretty=format:"- %s")"
           {
             echo "changelog<<EOF"
             printf '%s\n' "$changelog"


### PR DESCRIPTION
## 📝 Overview

- Fixed changelog generation logic to exclude the current release tag's commit from the release notes.

## 😮 Motivation and Background

- The changelog previously included the version bump commit for the current release due to the use of `git describe --tags` which returned the current tag.
- This caused the current version's tag to appear in its own release notes, which was redundant and misleading.

## ✅ Changes

- [ ] Feature added
- [x] Bug fixed
- [ ] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- Updated the `Generate changelog` step in GitHub Actions to get the previous tag using `git tag --sort=-v:refname` excluding the current tag.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed

