### PR TITLE
fix: Exclude bump version commit from changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           current_tag="${GITHUB_REF#refs/tags/}"
           previous_tag=$(git tag --sort=-v:refname | grep -v "^${current_tag}$" | head -n 1)
           echo "Found previous tag: $previous_tag"
-          changelog="$(git log ${previous_tag}^..HEAD --pretty=format:"- %s")"
+          changelog="$(git log HEAD ^${previous_tag} --pretty=format:"- %s" | grep -v 'chore: bump version')"
           {
             echo "changelog<<EOF"
             printf '%s\n' "$changelog"


### PR DESCRIPTION
## 📝 Overview

- Excluded the "chore: bump version" commit from the changelog generated during release.

## 😮 Motivation and Background

- The changelog was previously including the version bump commit from the last release, which was unnecessary and cluttered the release notes.

## ✅ Changes

- [ ] Feature added
- [x] Bug fixed
- [ ] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- The changelog generation step now filters out lines containing "chore: bump version" using `grep -v`.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed