### PR TITLE
refactor: rename param key from path to dirPath for clarity and remove unused fs/path imports

### DIFF
--- a/src/cli/core/generate-path-structure.test.ts
+++ b/src/cli/core/generate-path-structure.test.ts
@@ -41,7 +41,7 @@ describe("generatePages", () => {
         },
       ],
       paramsTypes: [
-        { paramsType: '{ "hoge": string }', path: "/[hoge]/bar/route.ts" },
+        { paramsType: '{ "hoge": string }', dirPath: "/[hoge]/bar" },
       ],
     });
 

--- a/src/cli/core/generate-path-structure.ts
+++ b/src/cli/core/generate-path-structure.ts
@@ -1,5 +1,3 @@
-import fs from "fs";
-import path from "path";
 import {
   STATEMENT_TERMINATOR,
   NEWLINE,
@@ -30,9 +28,7 @@ export const generatePages = (outputPath: string, baseDir: string) => {
     keyTypes.join(" ,"),
     RPC4NEXT_CLIENT_IMPORT_PATH
   );
-  const dirParamsTypes = paramsTypes.map(({ paramsType, path: filePath }) => {
-    const stats = fs.statSync(filePath);
-    const dirPath = stats.isFile() ? path.dirname(filePath) : filePath;
+  const dirParamsTypes = paramsTypes.map(({ paramsType, dirPath }) => {
     const params = `export type Params = ${paramsType}${STATEMENT_TERMINATOR}`;
 
     return {

--- a/src/cli/core/route-scanner.test.ts
+++ b/src/cli/core/route-scanner.test.ts
@@ -199,7 +199,7 @@ describe("scanAppDir", () => {
     const expectedParamsTypes = [
       {
         paramsType: '{ "id": string }',
-        path: "/testApp/api/users/[id]/route.ts",
+        dirPath: "/testApp/api/users/[id]",
       },
     ];
 
@@ -473,11 +473,11 @@ describe("scanAppDir", () => {
     const expectedParamsTypes = [
       {
         paramsType: '{ "names": string[] | undefined }',
-        path: "/testApp/OptionalCatchAll/user/[[...names]]/page.tsx",
+        dirPath: "/testApp/OptionalCatchAll/user/[[...names]]",
       },
       {
         paramsType: '{ "user": string; "names": string[]; }',
-        path: "/testApp/catchAll/[user]/[...names]/page.tsx",
+        dirPath: "/testApp/catchAll/[user]/[...names]",
       },
     ];
     expectedParamsTypes.forEach((paramsType, i) => {

--- a/src/cli/core/route-scanner.ts
+++ b/src/cli/core/route-scanner.ts
@@ -24,6 +24,16 @@ import {
 } from "../../lib/constants";
 import type { EndPointFileNames } from "./types";
 
+type ImportObj = {
+  statement: string;
+  path: string;
+};
+
+type ParamsType = {
+  paramsType: string;
+  dirPath: string;
+};
+
 const endPointFileNames = new Set(END_POINT_FILE_NAMES);
 
 export const hasTargetFiles = (dirPath: string): boolean => {
@@ -86,14 +96,8 @@ export const scanAppDir = (
   }[] = []
 ): {
   pathStructure: string;
-  imports: {
-    statement: string;
-    path: string;
-  }[];
-  paramsTypes: {
-    paramsType: string;
-    path: string;
-  }[];
+  imports: ImportObj[];
+  paramsTypes: ParamsType[];
 } => {
   if (scanAppDirCache.has(input)) {
     return scanAppDirCache.get(input)!;
@@ -101,10 +105,10 @@ export const scanAppDir = (
 
   indent += INDENT;
   const pathStructures: string[] = [];
-  const imports: { statement: string; path: string }[] = [];
+  const imports: ImportObj[] = [];
   const types: string[] = [];
   const params = [...parentParams];
-  const paramsTypes: { paramsType: string; path: string }[] = [];
+  const paramsTypes: ParamsType[] = [];
 
   const entries = fs
     .readdirSync(input, { withFileTypes: true })
@@ -234,7 +238,10 @@ export const scanAppDir = (
           return { name: paramName, type: paramType };
         });
         const paramsType = createObjectType(fields);
-        paramsTypes.push({ paramsType, path: fullPath.replace(/\\/g, "/") });
+        paramsTypes.push({
+          paramsType,
+          dirPath: path.dirname(fullPath.replace(/\\/g, "/")),
+        });
         types.push(createRecodeType(TYPE_KEY_PARAMS, paramsType));
       }
     }


### PR DESCRIPTION
## 📝 Overview

- Renamed the `path` key in `paramsTypes` to `dirPath` to better reflect its content.
- Removed unused `fs` and `path` imports from `generate-path-structure.ts`.

## 😨 Motivation and Background

- The `path` key in `paramsTypes` was misleading since it referred to a directory, not a file. Renaming it to `dirPath` improves code readability and semantic clarity.
- `fs` and `path` modules were no longer used after the change and were removed for cleanup.

## ✅ Changes

- [ ] Feature added  
- [ ] Bug fixed  
- [x] Refactored  
- [ ] Documentation updated  

## 💡 Notes / Screenshots

- None

## 🔄 Testing

- [x] `npm run lint` passed  
- [x] `npm run test` passed  
- [x] Manual verification completed