### PR TITLE
refactor: improve CLI structure logic

### DIFF
--- a/src/cli/cli-handler.ts
+++ b/src/cli/cli-handler.ts
@@ -1,6 +1,7 @@
 import path from "path";
+import { EXIT_FAILURE, EXIT_SUCCESS } from "./constants";
 import { generate } from "./generator";
-import { CliOptions, Logger } from "./types";
+import { CliOptions, ExitCode, Logger } from "./types";
 import { setupWatcher } from "./watcher";
 
 export const handleCli = (
@@ -8,7 +9,7 @@ export const handleCli = (
   outputPath: string,
   options: CliOptions,
   logger: Logger
-): number => {
+): ExitCode => {
   const resolvedBaseDir = path.resolve(baseDir).replace(/\\/g, "/");
   const resolvedOutputPath = path.resolve(outputPath).replace(/\\/g, "/");
 
@@ -18,7 +19,7 @@ export const handleCli = (
   if (options.paramsFile !== undefined && !paramsFileName) {
     logger.error("Error: --params-file requires a filename.");
 
-    return 1;
+    return EXIT_FAILURE;
   }
 
   if (options.watch) {
@@ -28,7 +29,7 @@ export const handleCli = (
         generate({
           baseDir: resolvedBaseDir,
           outputPath: resolvedOutputPath,
-          paramsFileName: options.paramsFile || null,
+          paramsFileName,
           logger,
         });
       },
@@ -38,10 +39,10 @@ export const handleCli = (
     generate({
       baseDir: resolvedBaseDir,
       outputPath: resolvedOutputPath,
-      paramsFileName: options.paramsFile || null,
+      paramsFileName,
       logger,
     });
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 };

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { handleCli } from "./cli-handler";
 import { createLogger } from "./logger";
-import { Logger } from "./types";
+import { CliOptions, Logger } from "./types";
 
 export const runCli = (argv: string[], logger: Logger = createLogger()) => {
   const program = new Command();
@@ -20,12 +20,14 @@ export const runCli = (argv: string[], logger: Logger = createLogger()) => {
       "-p, --params-file [filename]",
       "Generate params types file with specified filename"
     )
-    .action(async (baseDir, outputPath, options) => {
-      const exitCode = handleCli(baseDir, outputPath, options, logger);
-      if (!options.watch) {
-        process.exit(exitCode);
+    .action(
+      async (baseDir: string, outputPath: string, options: CliOptions) => {
+        const exitCode = handleCli(baseDir, outputPath, options, logger);
+        if (!options.watch) {
+          process.exit(exitCode as number);
+        }
       }
-    });
+    );
 
   program.parse(argv);
 };

--- a/src/cli/constants.ts
+++ b/src/cli/constants.ts
@@ -1,0 +1,6 @@
+import { ErrorExitCode, SuccessExitCode } from "./types";
+
+export const END_POINT_FILE_NAMES = ["page.tsx", "route.ts"] as const;
+
+export const EXIT_SUCCESS: SuccessExitCode = 0;
+export const EXIT_FAILURE: ErrorExitCode = 1;

--- a/src/cli/core/constants.ts
+++ b/src/cli/core/constants.ts
@@ -1,4 +1,3 @@
-export const END_POINT_FILE_NAMES = ["page.tsx", "route.ts"] as const;
 export const QUERY_TYPES = ["Query", "OptionalQuery"] as const;
 
 export const INDENT = "  ";

--- a/src/cli/core/route-scanner.ts
+++ b/src/cli/core/route-scanner.ts
@@ -7,13 +7,7 @@ import fs from "fs";
 import path from "path";
 
 import { scanAppDirCache, visitedDirsCache } from "./cache";
-import {
-  INDENT,
-  TYPE_END_POINT,
-  TYPE_KEY_PARAMS,
-  NEWLINE,
-  END_POINT_FILE_NAMES,
-} from "./constants";
+import { INDENT, TYPE_END_POINT, TYPE_KEY_PARAMS, NEWLINE } from "./constants";
 import { scanQuery, scanRoute } from "./scan-utils";
 import { createObjectType, createRecodeType } from "./type-utils";
 import {
@@ -22,7 +16,8 @@ import {
   DYNAMIC_PREFIX,
   HTTP_METHODS_EXCLUDE_OPTIONS,
 } from "../../lib/constants";
-import type { EndPointFileNames } from "./types";
+import { END_POINT_FILE_NAMES } from "../constants";
+import { EndPointFileNames } from "../types";
 
 type ImportObj = {
   statement: string;

--- a/src/cli/core/route-scanner.ts
+++ b/src/cli/core/route-scanner.ts
@@ -98,6 +98,7 @@ export const scanAppDir = (
     return scanAppDirCache.get(input)!;
   }
 
+  const prevIndent = indent;
   indent += INDENT;
   const pathStructures: string[] = [];
   const imports: ImportObj[] = [];
@@ -176,7 +177,7 @@ export const scanAppDir = (
       } = scanAppDir(
         output,
         fullPath,
-        isSkipDir ? indent.replace(INDENT, "") : indent,
+        isSkipDir ? prevIndent : indent,
         nextParams
       );
 
@@ -239,14 +240,16 @@ export const scanAppDir = (
   });
 
   const typeString = types.join(" & ");
+
+  const hasPaths = pathStructures.length > 0;
+  const pathStructureBody = hasPaths
+    ? `{${NEWLINE}${pathStructures.join(`,${NEWLINE}`)}${NEWLINE}${prevIndent}}`
+    : "";
+
   const pathStructure =
-    pathStructures.length > 0
-      ? `${typeString}${
-          typeString ? " & " : ""
-        }{${NEWLINE}${pathStructures.join(
-          `,${NEWLINE}`
-        )}${NEWLINE}${indent.replace(INDENT, "")}}`
-      : typeString;
+    typeString && pathStructureBody
+      ? `${typeString} & ${pathStructureBody}`
+      : typeString || pathStructureBody;
 
   const result = {
     pathStructure,

--- a/src/cli/core/route-scanner.ts
+++ b/src/cli/core/route-scanner.ts
@@ -17,7 +17,7 @@ import {
   HTTP_METHODS_EXCLUDE_OPTIONS,
 } from "../../lib/constants";
 import { END_POINT_FILE_NAMES } from "../constants";
-import { EndPointFileNames } from "../types";
+import type { EndPointFileNames } from "../types";
 
 type ImportObj = {
   statement: string;
@@ -155,18 +155,21 @@ export const scanAppDir = (
         return { paramName: param, keyName: `${prefix}${param}` };
       })();
 
-      let nextParams = params;
-      if (isDynamic || isCatchAll || isOptionalCatchAll) {
-        const routeType = {
-          isGroup,
-          isParallel,
-          isOptionalCatchAll,
-          isCatchAll,
-          isDynamic,
-        };
+      const nextParams = (() => {
+        if (isDynamic || isCatchAll || isOptionalCatchAll) {
+          const routeType = {
+            isGroup,
+            isParallel,
+            isOptionalCatchAll,
+            isCatchAll,
+            isDynamic,
+          };
 
-        nextParams = [...params, { paramName, routeType }];
-      }
+          return [...params, { paramName, routeType }];
+        }
+
+        return params;
+      })();
 
       const isSkipDir = isGroup || isParallel;
 

--- a/src/cli/core/route-scanner.ts
+++ b/src/cli/core/route-scanner.ts
@@ -182,8 +182,7 @@ export const scanAppDir = (
             ]
           : params;
 
-      // For group or parallel segments, do not change the indent
-      const usePreviousIndent = isGroup || isParallel;
+      const isSkipDir = isGroup || isParallel;
 
       const {
         pathStructure: childPathStructure,
@@ -192,14 +191,14 @@ export const scanAppDir = (
       } = scanAppDir(
         output,
         fullPath,
-        usePreviousIndent ? previousIndent : currentIndent,
+        isSkipDir ? previousIndent : currentIndent,
         nextParams
       );
 
       imports.push(...childImports);
       paramsTypes.push(...childParamsTypes);
 
-      if (usePreviousIndent) {
+      if (isSkipDir) {
         // Extract only the inner part inside `{}` from the child output
         const match = childPathStructure.match(/^\s*\{([\s\S]*)\}\s*$/);
         const childContent = match ? match[1].trim() : "";

--- a/src/cli/core/route-scanner.ts
+++ b/src/cli/core/route-scanner.ts
@@ -120,24 +120,20 @@ export const scanAppDir = (
     .sort();
 
   entries.forEach((entry) => {
-    const fullPath = path.join(input, entry.name);
-    const nameWithoutExt = entry.isFile()
-      ? entry.name.replace(/\.[^/.]+$/, "")
-      : entry.name;
+    const fullPath = path.join(input, entry.name).replace(/\\/g, "/");
 
     if (entry.isDirectory()) {
-      const isGroup =
-        nameWithoutExt.startsWith("(") && nameWithoutExt.endsWith(")");
-      const isParallel = nameWithoutExt.startsWith("@");
+      const entryName = entry.name;
+      const isGroup = entryName.startsWith("(") && entryName.endsWith(")");
+      const isParallel = entryName.startsWith("@");
       const isOptionalCatchAll =
-        nameWithoutExt.startsWith("[[...") && nameWithoutExt.endsWith("]]");
+        entryName.startsWith("[[...") && entryName.endsWith("]]");
       const isCatchAll =
-        nameWithoutExt.startsWith("[...") && nameWithoutExt.endsWith("]");
-      const isDynamic =
-        nameWithoutExt.startsWith("[") && nameWithoutExt.endsWith("]");
+        entryName.startsWith("[...") && entryName.endsWith("]");
+      const isDynamic = entryName.startsWith("[") && entryName.endsWith("]");
 
       const { paramName, keyName } = (() => {
-        let param = nameWithoutExt;
+        let param = entryName;
         // Remove []
         if (isDynamic) {
           param = param.replace(/^\[+|\]+$/g, "");
@@ -235,7 +231,7 @@ export const scanAppDir = (
         const paramsType = createObjectType(fields);
         paramsTypes.push({
           paramsType,
-          dirPath: path.dirname(fullPath.replace(/\\/g, "/")),
+          dirPath: path.dirname(fullPath),
         });
         types.push(createRecodeType(TYPE_KEY_PARAMS, paramsType));
       }

--- a/src/cli/core/scan-utils.ts
+++ b/src/cli/core/scan-utils.ts
@@ -33,7 +33,7 @@ export const scanFile = <T extends string | undefined>(
   };
 };
 
-// query定義作成
+// Create query definitions
 export const scanQuery = (outputFile: string, inputFile: string) => {
   return scanFile(
     outputFile,
@@ -52,7 +52,7 @@ export const scanQuery = (outputFile: string, inputFile: string) => {
   );
 };
 
-// route定義作成
+// Create route definitions
 export const scanRoute = (
   outputFile: string,
   inputFile: string,

--- a/src/cli/core/types.ts
+++ b/src/cli/core/types.ts
@@ -1,3 +1,0 @@
-import type { END_POINT_FILE_NAMES } from "./constants";
-
-export type EndPointFileNames = (typeof END_POINT_FILE_NAMES)[number];

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,3 +1,7 @@
+import { END_POINT_FILE_NAMES } from "./constants";
+
+export type EndPointFileNames = (typeof END_POINT_FILE_NAMES)[number];
+
 export interface Logger {
   info: (msg: string) => void;
   success: (msg: string) => void;
@@ -8,3 +12,18 @@ export interface CliOptions {
   watch?: boolean;
   paramsFile?: string;
 }
+
+type BuildRange<
+  N extends number,
+  Result extends number[] = [],
+> = Result["length"] extends N
+  ? Result
+  : BuildRange<N, [...Result, Result["length"]]>;
+
+type NumericRange<F extends number, T extends number> =
+  | Exclude<BuildRange<T>, BuildRange<F>>
+  | F;
+
+export type SuccessExitCode = 0;
+export type ErrorExitCode = NumericRange<1, 256>;
+export type ExitCode = SuccessExitCode | ErrorExitCode;

--- a/src/cli/watcher.ts
+++ b/src/cli/watcher.ts
@@ -1,4 +1,5 @@
 import chokidar from "chokidar";
+import { END_POINT_FILE_NAMES } from "./constants";
 import {
   clearScanAppDirCacheAbove,
   clearVisitedDirsCacheAbove,
@@ -13,8 +14,8 @@ export const setupWatcher = (
 ) => {
   logger.info(`Watching ${baseDir}...`);
 
-  const isTargetFiles = (path: string) =>
-    path.endsWith("route.ts") || path.endsWith("page.tsx");
+  const isTargetFiles = (path: string): boolean =>
+    END_POINT_FILE_NAMES.some((fileName) => path.endsWith(fileName));
 
   const changedPaths = new Set<string>();
 


### PR DESCRIPTION
## 📝 Overview

- Major refactor of the `scanAppDir` function and its related helpers for improved clarity and maintainability.
- Extracted `extractParamInfo` to handle dynamic/catch-all/optional segment name resolution.
- Rewrote `hasTargetFiles` for better readability and fixed a typo in comments.
- Refined how `typeString` and `pathStructureBody` are generated and composed.
- Introduced `typeFragments` for clearer type accumulation logic.
- Improved indent handling between recursive calls with `previousIndent` and `currentIndent`.
- Replaced `forEach` with `for...of` and reduced nesting to enhance readability.

## 😮 Motivation and Background

- The previous structure of route scanning logic was complex and deeply nested, making it harder to maintain and extend.
- This refactor splits responsibilities, improves naming, and isolates formatting concerns.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [x] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- Functionality is preserved; only internal structure and readability were improved.
- Clean separation of concerns in parameter extraction and type/path structure generation.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed