### PR TITLE
update: enhance logger output formatting and test coverage

### DIFF
--- a/src/cli/cli-handler.ts
+++ b/src/cli/cli-handler.ts
@@ -1,8 +1,8 @@
 import path from "path";
 import { EXIT_FAILURE, EXIT_SUCCESS } from "./constants";
 import { generate } from "./generator";
-import { CliOptions, ExitCode, Logger } from "./types";
 import { setupWatcher } from "./watcher";
+import type { CliOptions, ExitCode, Logger } from "./types";
 
 export const handleCli = (
   baseDir: string,

--- a/src/cli/constants.ts
+++ b/src/cli/constants.ts
@@ -4,3 +4,7 @@ export const END_POINT_FILE_NAMES = ["page.tsx", "route.ts"] as const;
 
 export const EXIT_SUCCESS: SuccessExitCode = 0;
 export const EXIT_FAILURE: ErrorExitCode = 1;
+
+export const SUCCESS_INDENT_LEVEL = 1;
+export const SUCCESS_PAD_LENGTH = 20;
+export const SUCCESS_SEPARATOR = "→";

--- a/src/cli/generator.test.ts
+++ b/src/cli/generator.test.ts
@@ -1,7 +1,14 @@
 import fs from "fs";
+import path from "path";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  SUCCESS_INDENT_LEVEL,
+  SUCCESS_PAD_LENGTH,
+  SUCCESS_SEPARATOR,
+} from "./constants";
 import * as generatePathStructure from "./core/generate-path-structure";
 import { generate } from "./generator";
+import { padMessage } from "./logger";
 
 describe("generate", () => {
   const logger = {
@@ -33,18 +40,33 @@ describe("generate", () => {
       logger,
     });
 
-    expect(logger.info).toHaveBeenCalledWith("Generating...");
+    expect(logger.info).toHaveBeenCalledWith(
+      "Types regenerated due to file change",
+      {
+        event: "generate",
+      }
+    );
+
     expect(generatePathStructure.generatePages).toHaveBeenCalledWith(
       outputPath,
       baseDir
     );
+
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       outputPath,
       "generated-type-content"
     );
-    expect(logger.success).toHaveBeenCalledWith(
-      `Generated types at ${outputPath}`
+
+    const expectedSuccessMessage = padMessage(
+      "Path structure type",
+      path.relative(process.cwd(), outputPath),
+      SUCCESS_SEPARATOR,
+      SUCCESS_PAD_LENGTH
     );
+
+    expect(logger.success).toHaveBeenCalledWith(expectedSuccessMessage, {
+      indentLevel: SUCCESS_INDENT_LEVEL,
+    });
   });
 
   it("should generate types and params files when paramsFileName is provided", () => {
@@ -65,28 +87,50 @@ describe("generate", () => {
       logger,
     });
 
-    expect(logger.info).toHaveBeenCalledWith("Generating...");
+    expect(logger.info).toHaveBeenCalledWith(
+      "Types regenerated due to file change",
+      {
+        event: "generate",
+      }
+    );
+
     expect(generatePathStructure.generatePages).toHaveBeenCalledWith(
       outputPath,
       baseDir
     );
+
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       outputPath,
       "generated-type-content"
     );
+
     expect(fs.writeFileSync).toHaveBeenCalledWith(
-      "dir1/params.ts",
+      path.join("dir1", paramsFileName),
       "params-type-1"
     );
     expect(fs.writeFileSync).toHaveBeenCalledWith(
-      "dir2/params.ts",
+      path.join("dir2", paramsFileName),
       "params-type-2"
     );
-    expect(logger.success).toHaveBeenCalledWith(
-      `Generated types at ${outputPath}`
+
+    const expectedTypeMessage = padMessage(
+      "Path structure type",
+      path.relative(process.cwd(), outputPath),
+      SUCCESS_SEPARATOR,
+      SUCCESS_PAD_LENGTH
     );
-    expect(logger.success).toHaveBeenCalledWith(
-      `Generated params type at ${paramsFileName}`
+    expect(logger.success).toHaveBeenCalledWith(expectedTypeMessage, {
+      indentLevel: SUCCESS_INDENT_LEVEL,
+    });
+
+    const expectedParamsMessage = padMessage(
+      "Params types",
+      paramsFileName,
+      SUCCESS_SEPARATOR,
+      SUCCESS_PAD_LENGTH
     );
+    expect(logger.success).toHaveBeenCalledWith(expectedParamsMessage, {
+      indentLevel: SUCCESS_INDENT_LEVEL,
+    });
   });
 });

--- a/src/cli/generator.ts
+++ b/src/cli/generator.ts
@@ -1,6 +1,13 @@
 import fs from "fs";
+import path from "path";
+import {
+  SUCCESS_SEPARATOR,
+  SUCCESS_PAD_LENGTH,
+  SUCCESS_INDENT_LEVEL,
+} from "./constants";
 import { generatePages } from "./core/generate-path-structure";
-import { Logger } from "./types";
+import { padMessage } from "./logger";
+import type { Logger } from "./types";
 
 export const generate = ({
   baseDir,
@@ -13,17 +20,36 @@ export const generate = ({
   paramsFileName: string | null;
   logger: Logger;
 }) => {
-  logger.info("Generating...");
+  logger.info("Types regenerated due to file change", { event: "generate" });
+
   const { pathStructure, paramsTypes } = generatePages(outputPath, baseDir);
 
   fs.writeFileSync(outputPath, pathStructure);
-  logger.success(`Generated types at ${outputPath}`);
+  logger.success(
+    padMessage(
+      "Path structure type",
+      path.relative(process.cwd(), outputPath),
+      SUCCESS_SEPARATOR,
+      SUCCESS_PAD_LENGTH
+    ),
+    { indentLevel: SUCCESS_INDENT_LEVEL }
+  );
 
   if (paramsFileName) {
     paramsTypes.forEach(({ paramsType, dirPath }) => {
-      const filePath = `${dirPath}/${paramsFileName}`;
+      const filePath = path.join(dirPath, paramsFileName);
       fs.writeFileSync(filePath, paramsType);
     });
-    logger.success(`Generated params type at ${paramsFileName}`);
+    logger.success(
+      padMessage(
+        "Params types",
+        paramsFileName,
+        SUCCESS_SEPARATOR,
+        SUCCESS_PAD_LENGTH
+      ),
+      {
+        indentLevel: SUCCESS_INDENT_LEVEL,
+      }
+    );
   }
 };

--- a/src/cli/logger.test.ts
+++ b/src/cli/logger.test.ts
@@ -1,3 +1,4 @@
+import chalk from "chalk";
 import {
   describe,
   it,
@@ -7,7 +8,8 @@ import {
   afterAll,
   beforeEach,
 } from "vitest";
-import { createLogger } from "./logger";
+import { INDENT } from "./core/constants";
+import { createLogger, padMessage } from "./logger";
 
 describe("createLogger", () => {
   const originalLog = console.log;
@@ -31,21 +33,67 @@ describe("createLogger", () => {
     mockError.mockClear();
   });
 
-  it("should call console.log on info", () => {
+  it("should log info without options", () => {
     const logger = createLogger();
     logger.info("info message");
     expect(mockLog).toHaveBeenCalledWith("info message");
   });
 
-  it("should call console.log on success", () => {
+  it("should log info with indent and event", () => {
     const logger = createLogger();
-    logger.success("success message");
-    expect(mockLog).toHaveBeenCalledWith("success message");
+    const indent = INDENT.repeat(2);
+    logger.info("info message", { indentLevel: 2, event: "scan" });
+    expect(mockLog).toHaveBeenCalledWith(
+      `${indent}${chalk.cyan("[scan]")} info message`
+    );
   });
 
-  it("should call console.error on error", () => {
+  it("should log success without options", () => {
+    const logger = createLogger();
+    logger.success("success message");
+    expect(mockLog).toHaveBeenCalledWith(`${chalk.green("✓")} success message`);
+  });
+
+  it("should log success with indent", () => {
+    const logger = createLogger();
+    const indent = INDENT.repeat(1);
+    logger.success("success message", { indentLevel: 1 });
+    expect(mockLog).toHaveBeenCalledWith(
+      `${indent}${chalk.green("✓")} success message`
+    );
+  });
+
+  it("should log error without options", () => {
     const logger = createLogger();
     logger.error("error message");
-    expect(mockError).toHaveBeenCalledWith("error message");
+    expect(mockError).toHaveBeenCalledWith(
+      `${chalk.red("✗")} ${chalk.red("error message")}`
+    );
+  });
+
+  it("should log error with indent", () => {
+    const logger = createLogger();
+    const indent = INDENT.repeat(1);
+    logger.error("error message", { indentLevel: 1 });
+    expect(mockError).toHaveBeenCalledWith(
+      `${indent}${chalk.red("✗")} ${chalk.red("error message")}`
+    );
+  });
+});
+
+describe("padMessage", () => {
+  it("should pad label and format the message with default separator", () => {
+    const result = padMessage("Label", "Value");
+    expect(result).toBe("Label                    → Value");
+  });
+
+  it("should use custom separator", () => {
+    const result = padMessage("Label", "Value", "=");
+    expect(result).toBe("Label                    = Value");
+  });
+
+  it("should pad to given target length", () => {
+    const result = padMessage("Short", "Data", "→", 10);
+    expect(result).toBe("Short      → Data");
   });
 });

--- a/src/cli/logger.ts
+++ b/src/cli/logger.ts
@@ -1,9 +1,36 @@
-import { Logger } from "./types";
+import chalk from "chalk";
+import { INDENT } from "./core/constants";
+import type { Logger } from "./types";
+
+export const padMessage = (
+  label: string,
+  value: string,
+  separator = "→",
+  targetLength = 24
+) => {
+  return label.padEnd(targetLength) + ` ${separator} ${value}`;
+};
+
+const createIndent = (level: number = 0) => INDENT.repeat(level);
 
 export const createLogger = (): Logger => {
   return {
-    info: (msg) => console.log(msg),
-    success: (msg) => console.log(msg),
-    error: (msg) => console.error(msg),
+    info: (msg, options = {}) => {
+      const { indentLevel = 0, event } = options;
+      const prefix = event ? `${chalk.cyan(`[${event}]`)} ` : "";
+      console.log(`${createIndent(indentLevel)}${prefix}${msg}`);
+    },
+
+    success: (msg, options = {}) => {
+      const { indentLevel = 0 } = options;
+      console.log(`${createIndent(indentLevel)}${chalk.green("✓")} ${msg}`);
+    },
+
+    error: (msg, options = {}) => {
+      const { indentLevel = 0 } = options;
+      console.error(
+        `${createIndent(indentLevel)}${chalk.red("✗")} ${chalk.red(msg)}`
+      );
+    },
   };
 };

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,16 +1,21 @@
-import { END_POINT_FILE_NAMES } from "./constants";
+import type { END_POINT_FILE_NAMES } from "./constants";
 
 export type EndPointFileNames = (typeof END_POINT_FILE_NAMES)[number];
-
-export interface Logger {
-  info: (msg: string) => void;
-  success: (msg: string) => void;
-  error: (msg: string) => void;
-}
 
 export interface CliOptions {
   watch?: boolean;
   paramsFile?: string;
+}
+
+type LogOptions = {
+  indentLevel?: number;
+  event?: string;
+};
+
+export interface Logger {
+  info: (msg: string, options?: LogOptions) => void;
+  success: (msg: string, options?: Pick<LogOptions, "indentLevel">) => void;
+  error: (msg: string, options?: Pick<LogOptions, "indentLevel">) => void;
 }
 
 type BuildRange<


### PR DESCRIPTION
## 📝 Overview

- Enhanced CLI logger output with better formatting and contextual information
- Introduced `padMessage` utility for aligned label-value formatting in logs
- Used relative paths for log output consistency across environments
- Added constants (`SUCCESS_PAD_LENGTH`, `SUCCESS_SEPARATOR`, etc.) to control formatting
- Updated `generate` and `watcher` to use enhanced logger style
- Improved test coverage for logger behavior

## 🤔 Motivation and Background

- Previous log messages lacked consistent alignment and formatting
- Needed clearer, structured logs for better readability and user experience in CLI tools
- Logger test coverage was minimal and didn’t account for indentation or event labeling

## ✅ Changes

- [x] Feature added: `padMessage` utility
- [x] Refactored: logger output formatting
- [x] Refactored: use of constants for formatting
- [x] Test updated: full coverage for logger outputs (info, success, error)
- [x] Test updated: watcher and generator behavior with updated logger

## 💡 Notes / Screenshots

- `Path structure type` and `Params types` logs now padded and include indentation
- Event labels like `[watch]`, `[change]` added to logs for better context
- Improved test reliability with relative path calculation and proper mocking

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed