### PR TITLE
update: replace log message with more generic "Generating types..."

### DIFF
--- a/src/cli/generator.test.ts
+++ b/src/cli/generator.test.ts
@@ -40,12 +40,9 @@ describe("generate", () => {
       logger,
     });
 
-    expect(logger.info).toHaveBeenCalledWith(
-      "Types regenerated due to file change",
-      {
-        event: "generate",
-      }
-    );
+    expect(logger.info).toHaveBeenCalledWith("Generating types...", {
+      event: "generate",
+    });
 
     expect(generatePathStructure.generatePages).toHaveBeenCalledWith(
       outputPath,
@@ -87,12 +84,9 @@ describe("generate", () => {
       logger,
     });
 
-    expect(logger.info).toHaveBeenCalledWith(
-      "Types regenerated due to file change",
-      {
-        event: "generate",
-      }
-    );
+    expect(logger.info).toHaveBeenCalledWith("Generating types...", {
+      event: "generate",
+    });
 
     expect(generatePathStructure.generatePages).toHaveBeenCalledWith(
       outputPath,

--- a/src/cli/generator.ts
+++ b/src/cli/generator.ts
@@ -20,7 +20,7 @@ export const generate = ({
   paramsFileName: string | null;
   logger: Logger;
 }) => {
-  logger.info("Types regenerated due to file change", { event: "generate" });
+  logger.info("Generating types...", { event: "generate" });
 
   const { pathStructure, paramsTypes } = generatePages(outputPath, baseDir);
 


### PR DESCRIPTION
## 📝 Overview

- Updated the log message in the `generate` function to use a more generic and context-agnostic phrase.
- Updated corresponding tests to reflect the change in log output.

## 😮 Motivation and Background

- The original message "Types regenerated due to file change" could be misleading during the initial execution, as it implies a regeneration rather than a first-time generation.
- A more neutral message like "Generating types..." provides clarity regardless of the execution context.

## ✅ Changes

- [x] Log message updated in `generator.ts`
- [x] Adjusted unit tests in `generator.test.ts` to match the new message

## 💡 Notes / Screenshots

- No functionality was changed. This is a purely cosmetic/logical improvement for developer clarity.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed