### PR TITLE
chore: add GitHub Actions workflow to auto-approve PRs from repo owner

### DIFF
--- a/.github/workflows/pr-auto-approve.yaml
+++ b/.github/workflows/pr-auto-approve.yaml
@@ -1,0 +1,16 @@
+name: Auto Approve
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+jobs:
+  approve:
+    if: github.event.pull_request.user.login == github.repository_owner && ! github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@v4


### PR DESCRIPTION
## 📝 Overview

- Added a GitHub Actions workflow to automatically approve pull requests created by the repository owner.

## 🧐 Motivation and Background

- Since the repository has a rule requiring PR approval before merging, and the maintainer is the only contributor, this workflow allows PRs to be automatically approved if created by the repo owner.

## ✅ Changes

- [x] Feature added: Introduced `.github/workflows/pr-auto-approve.yaml` with `hmarr/auto-approve-action@v4`

## 💡 Notes / Screenshots

- Auto-approval only happens if the PR is opened by the repository owner and is not a draft.

## 🗑️ Testing

- [ ] `npm run lint` passed
- [ ] `npm run test` passed
- [x] Manual verification completed: Confirmed that PRs by the repo owner are auto-approved when opened or updated