### PR TITLE
chore: configure Git user for release PR creation workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -33,6 +33,11 @@ jobs:
           branch=$(git remote show origin | grep 'HEAD branch' | awk '{print $NF}')
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
+      - name: Setup Git user
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+
       - name: Create release branch
         run: |
           git checkout -b release/v${{ steps.extract_version.outputs.version }}


### PR DESCRIPTION
## 📝 Overview

- Configured Git user (name and email) in the `create-release-pr.yml` GitHub Actions workflow to ensure proper commit attribution when creating release branches.

## 😮 Motivation and Background

- Without configuring the Git user, automated commits may fail or not be attributed properly, potentially leading to issues with GitHub Actions or commit history clarity.

## ✅ Changes

- [x] Build-related change to CI/CD workflow
- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- Added `git config` steps for username and email as `github-actions` user before creating the release branch.

## 🗑️ Testing

- [ ] `npm run lint` passed
- [ ] `npm run test` passed
- [x] Manual verification completed via GitHub Actions run
