### PR TITLE
chore: move version bump into PR creation step for cleaner workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -38,18 +38,18 @@ jobs:
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
 
-      - name: Create release branch
+      - name: Bump version
         run: |
-          git checkout -b release/v${{ steps.extract_version.outputs.version }}
           npm version ${{ steps.extract_version.outputs.version }} --no-git-tag-version
           git add package.json package-lock.json
-          git commit -m "chore: bump version to v${{ steps.extract_version.outputs.version }}"
-          git push origin HEAD
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          base: ${{ steps.default_branch.outputs.branch }}
           branch: release/v${{ steps.extract_version.outputs.version }}
+          base: ${{ steps.default_branch.outputs.branch }}
+          commit-message: "chore: bump version to v${{ steps.extract_version.outputs.version }}"
           title: "Release v${{ steps.extract_version.outputs.version }}"
           body: "This PR prepares the release of v${{ steps.extract_version.outputs.version }}"
+          delete-branch: false
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 📝 Overview

- Refactored the release workflow to move the version bumping logic from a manual step into the `create-pull-request` action

## 😮 Motivation and Background

- Previously, the version bump and commit were handled before invoking the `create-pull-request` step. This sometimes led to commit history confusion and unnecessary pushes
- By embedding the version bump inside the PR step, we ensure a cleaner, atomic change that is tracked as part of the release PR itself

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [x] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- The `create-pull-request` action now performs the version bump, commits the change, and opens the PR
- Manual `git commit` and `git push` steps were removed

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed via test runs on GitHub Actions