### PR TITLE
chore/add-contents-permission-to-release-workflow

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - "package.json"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/v') && github.event.pull_request.user.login == 'github-actions[bot]'


### PR DESCRIPTION
## 📝 Overview

- Added the `permissions` field to the `release-on-merge.yml` workflow file to allow GitHub Actions to create releases.

## 🧐 Motivation and Background

- Without explicitly setting `permissions: contents: write`, GitHub's default `GITHUB_TOKEN` lacks the necessary permission to create a release, leading to a `403 Resource not accessible by integration` error.

## ✅ Changes

- [x] Tool configuration updated: Added `permissions: contents: write` to `.github/workflows/release-on-merge.yml`

## 💡 Notes / Screenshots

- This change is required for `softprops/action-gh-release` to function properly.

## 🔄 Testing

- [x] Verified that the release workflow completes without 403 errors
- [x] Manual verification completed by merging a release PR