### PR TITLE
chore: generate changelog from previous tag and include in release PRbody

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -43,6 +43,22 @@ jobs:
           npm version ${{ steps.extract_version.outputs.version }} --no-git-tag-version
           git add package.json package-lock.json
 
+      - name: Get previous tag
+        id: previous_tag
+        run: |
+          prev_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^v${{ steps.extract_version.outputs.version }}$" | head -n 1)
+          echo "tag=$prev_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          changelog=$(git log ${{ steps.previous_tag.outputs.tag }}..HEAD --pretty=format:"- %s" | grep -v 'chore: bump version')
+          {
+            echo "changelog<<EOF"
+            echo "$changelog"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
@@ -51,6 +67,11 @@ jobs:
           base: ${{ steps.default_branch.outputs.branch }}
           commit-message: "chore: bump version to v${{ steps.extract_version.outputs.version }}"
           title: "Release v${{ steps.extract_version.outputs.version }}"
-          body: "This PR prepares the release of v${{ steps.extract_version.outputs.version }}"
+          body: |
+            This PR prepares the release of v${{ steps.extract_version.outputs.version }}
+
+            ## Changes
+
+            ${{ steps.changelog.outputs.changelog }}
           delete-branch: false
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 📝 Overview

- Automatically generate a changelog from the previous release tag to HEAD
- Include the changelog content in the body of the release pull request

## 🧐 Motivation and Background

- Previously, release PRs only included a generic message and version number
- By including a changelog, reviewers and stakeholders can better understand what changes are included in the release

## ✅ Changes

- [x] Added a step to find the previous tag
- [x] Added a step to generate a changelog from the previous tag to HEAD
- [x] Injected the changelog into the PR body using `create-pull-request`

## 💡 Notes / Screenshots

- The changelog excludes version bump commits by filtering out `chore: bump version`

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed by pushing a tag and confirming the PR body contains the changelog