### PR TITLE
refactor: extract toPosixPath utility and replace inline path normalization

### DIFF
--- a/src/cli/cli-handler.ts
+++ b/src/cli/cli-handler.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import { EXIT_FAILURE, EXIT_SUCCESS } from "./constants";
+import { toPosixPath } from "./core/path-utils";
 import { generate } from "./generator";
 import { setupWatcher } from "./watcher";
 import type { CliOptions, ExitCode, Logger } from "./types";
@@ -36,8 +37,8 @@ export const handleCli = (
   options: CliOptions,
   logger: Logger
 ): ExitCode => {
-  const resolvedBaseDir = path.resolve(baseDir).replace(/\\/g, "/");
-  const resolvedOutputPath = path.resolve(outputPath).replace(/\\/g, "/");
+  const resolvedBaseDir = toPosixPath(path.resolve(baseDir));
+  const resolvedOutputPath = toPosixPath(path.resolve(outputPath));
 
   const paramsFileName =
     typeof options.paramsFile === "string" ? options.paramsFile : null;

--- a/src/cli/core/path-utils.test.ts
+++ b/src/cli/core/path-utils.test.ts
@@ -1,12 +1,8 @@
 import path from "path";
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { createRelativeImportPath } from "./path-utils";
+import { describe, it, expect, vi } from "vitest";
+import { createRelativeImportPath, toPosixPath } from "./path-utils";
 
 describe("createRelativeImportPath", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("should return a relative path between two files", () => {
     const outputFile = "/project/src/components/Button.js";
     const inputFile = "/project/src/utils/helpers.ts";
@@ -46,5 +42,27 @@ describe("createRelativeImportPath", () => {
 
     const result = createRelativeImportPath(outputFile, inputFile);
     expect(result).toBe("../utils/helpers");
+  });
+});
+
+describe("toPosixPath", () => {
+  it("converts backslashes to forward slashes", () => {
+    expect(toPosixPath("foo\\bar\\baz")).toBe("foo/bar/baz");
+  });
+
+  it("returns the same string if there are no backslashes", () => {
+    expect(toPosixPath("foo/bar/baz")).toBe("foo/bar/baz");
+  });
+
+  it("handles empty string", () => {
+    expect(toPosixPath("")).toBe("");
+  });
+
+  it("handles mixed slashes", () => {
+    expect(toPosixPath("foo/bar\\baz")).toBe("foo/bar/baz");
+  });
+
+  it("handles repeated backslashes", () => {
+    expect(toPosixPath("foo\\\\bar\\\\baz")).toBe("foo//bar//baz");
   });
 });

--- a/src/cli/core/path-utils.ts
+++ b/src/cli/core/path-utils.ts
@@ -4,10 +4,9 @@ export const createRelativeImportPath = (
   outputFile: string,
   inputFile: string
 ) => {
-  let relativePath = path
-    .relative(path.dirname(outputFile), inputFile)
-    .replace(/\\/g, "/")
-    .replace(/\.tsx?$/, "");
+  let relativePath = toPosixPath(
+    path.relative(path.dirname(outputFile), inputFile)
+  ).replace(/\.tsx?$/, "");
 
   // Add "./" if the file is in the same directory
   if (!relativePath.startsWith("../")) {
@@ -15,4 +14,8 @@ export const createRelativeImportPath = (
   }
 
   return relativePath;
+};
+
+export const toPosixPath = (p: string): string => {
+  return p.replace(/\\/g, "/");
 };

--- a/src/cli/core/route-scanner.ts
+++ b/src/cli/core/route-scanner.ts
@@ -17,6 +17,7 @@ import {
   HTTP_METHODS_EXCLUDE_OPTIONS,
 } from "../../lib/constants";
 import { END_POINT_FILE_NAMES } from "../constants";
+import { toPosixPath } from "./path-utils";
 import type { EndPointFileNames } from "../types";
 
 type ImportObj = {
@@ -146,7 +147,7 @@ export const scanAppDir = (
     .sort();
 
   for (const entry of entries) {
-    const fullPath = path.join(input, entry.name).replace(/\\/g, "/");
+    const fullPath = toPosixPath(path.join(input, entry.name));
 
     if (entry.isDirectory()) {
       const entryName = entry.name;


### PR DESCRIPTION
## 📝 Overview

- Extracted a reusable `toPosixPath` utility function to replace repeated use of `.replace(/\\/g, "/")`
- Replaced inline `.replace(/\\/g, "/")` calls in multiple files with `toPosixPath`
- Added unit tests for `toPosixPath` using Vitest

## 😮 Motivation and Background

- Several places in the codebase manually normalized Windows-style backslashes to POSIX-style forward slashes.
- Repeating `.replace(/\\/g, "/")` is error-prone and obscures intent.
- Extracting a utility improves readability, reusability, and testability.

## ✅ Changes

- [x] Refactored path normalization into `toPosixPath`
- [x] Replaced manual string replacement with `toPosixPath` in `cli-handler.ts`, `path-utils.ts`, and `route-scanner.ts`
- [x] Added test cases to `path-utils.test.ts`

## 💡 Notes / Screenshots

- The function resides in `src/cli/core/path-utils.ts`
- Covered edge cases like empty strings and mixed slashes in the test suite

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed in CLI and route scanner context