### PR TITLE
refactor: extract relative path logic to relativeFromRoot utility

### DIFF
--- a/src/cli/core/path-utils.test.ts
+++ b/src/cli/core/path-utils.test.ts
@@ -1,6 +1,10 @@
 import path from "path";
 import { describe, it, expect, vi } from "vitest";
-import { createRelativeImportPath, toPosixPath } from "./path-utils";
+import {
+  createRelativeImportPath,
+  relativeFromRoot,
+  toPosixPath,
+} from "./path-utils";
 
 describe("createRelativeImportPath", () => {
   it("should return a relative path between two files", () => {
@@ -64,5 +68,31 @@ describe("toPosixPath", () => {
 
   it("handles repeated backslashes", () => {
     expect(toPosixPath("foo\\\\bar\\\\baz")).toBe("foo//bar//baz");
+  });
+});
+
+describe("relativeFromRoot", () => {
+  it("returns correct relative path from project root", () => {
+    const mockCwd = "/Users/example/project";
+    const targetPath = "/Users/example/project/src/utils/file.ts";
+
+    vi.spyOn(process, "cwd").mockReturnValue(mockCwd);
+
+    const result = relativeFromRoot(targetPath);
+    expect(toPosixPath(result)).toBe("src/utils/file.ts");
+
+    vi.restoreAllMocks();
+  });
+
+  it('returns "../" when file is outside the cwd', () => {
+    const mockCwd = "/Users/example/project";
+    const targetPath = "/Users/example";
+
+    vi.spyOn(process, "cwd").mockReturnValue(mockCwd);
+
+    const result = relativeFromRoot(targetPath);
+    expect(toPosixPath(result)).toBe("..");
+
+    vi.restoreAllMocks();
   });
 });

--- a/src/cli/core/path-utils.ts
+++ b/src/cli/core/path-utils.ts
@@ -19,3 +19,7 @@ export const createRelativeImportPath = (
 export const toPosixPath = (p: string): string => {
   return p.replace(/\\/g, "/");
 };
+
+export const relativeFromRoot = (filePath: string): string => {
+  return path.relative(process.cwd(), filePath);
+};

--- a/src/cli/generator.ts
+++ b/src/cli/generator.ts
@@ -6,6 +6,7 @@ import {
   SUCCESS_INDENT_LEVEL,
 } from "./constants";
 import { generatePages } from "./core/generate-path-structure";
+import { relativeFromRoot } from "./core/path-utils";
 import { padMessage } from "./logger";
 import type { Logger } from "./types";
 
@@ -28,7 +29,7 @@ export const generate = ({
   logger.success(
     padMessage(
       "Path structure type",
-      path.relative(process.cwd(), outputPath),
+      relativeFromRoot(outputPath),
       SUCCESS_SEPARATOR,
       SUCCESS_PAD_LENGTH
     ),

--- a/src/cli/watcher.ts
+++ b/src/cli/watcher.ts
@@ -1,10 +1,10 @@
-import path from "path";
 import chokidar from "chokidar";
 import { END_POINT_FILE_NAMES } from "./constants";
 import {
   clearScanAppDirCacheAbove,
   clearVisitedDirsCacheAbove,
 } from "./core/cache";
+import { relativeFromRoot } from "./core/path-utils";
 import { debounceOnceRunningWithTrailing } from "./debounce";
 import type { Logger } from "./types";
 
@@ -13,7 +13,7 @@ export const setupWatcher = (
   onGenerate: () => void,
   logger: Logger
 ) => {
-  logger.info(`${path.relative(process.cwd(), baseDir)}`, {
+  logger.info(`${relativeFromRoot(baseDir)}`, {
     event: "watch",
   });
 
@@ -46,7 +46,7 @@ export const setupWatcher = (
     debouncedGenerate();
     watcher.on("all", (event, filePath) => {
       if (isTargetFiles(filePath)) {
-        const relativePath = path.relative(process.cwd(), filePath);
+        const relativePath = relativeFromRoot(filePath);
         logger.info(relativePath, { event });
         changedPaths.add(filePath);
         debouncedGenerate();


### PR DESCRIPTION
## 📝 Overview

- Extracted `path.relative(process.cwd(), ...)` logic into a reusable utility function named `relativeFromRoot`.
- Replaced direct calls to `path.relative` with `relativeFromRoot` in `generator.ts` and `watcher.ts`.
- Added unit tests for `relativeFromRoot`.

## 🧐 Motivation and Background

- To improve consistency and readability across the codebase by centralizing the logic for getting paths relative to the project root.
- Makes mocking and testing easier in the future, especially in non-Node environments.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [x] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- Function placed in `path-utils.ts` alongside other path-related helpers.
- Confirmed output normalization with `toPosixPath` in tests to handle platform differences.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed
