### PR TITLE
chore: separate base and Next.js version installation in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,14 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install dependencies
-        run: |
-          npm install next@${{ matrix.next-version }}
-          npm ci
+      - name: Install base dependencies
+        run: npm ci
+
+      - name: Install target Next.js version
+        run: npm install next@${{ matrix.next-version }}
+
+      - name: Next version
+        run: npx next --version
 
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
## 📝 Overview

Separated the installation of base dependencies and the target Next.js version in the CI workflow to improve clarity and prevent potential issues with lockfile handling.

## 🧐 Motivation and Background

Running `npm install next@...` followed by `npm ci` can override or ignore changes due to how `ci` strictly uses the lockfile. To ensure reproducibility and correctness, we now:

1. Install base dependencies with `npm ci`
2. Then install the specific Next.js version
3. Output the installed Next.js version for clarity in logs

## ✅ Changes

- [x] Separated `npm ci` and `npm install next@...` steps
- [x] Added step to output installed Next.js version via `npx next --version`

## 💡 Notes / Screenshots

- Ensures the lockfile remains consistent while allowing version matrix testing for Next.js

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed