### PR TITLE
test: add matrix testing for Node.js versions 18, 20, and 22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        node-version: [18, 20, 22]
         next-version: ["14.0.0", "15.0.0", "15.2.4"]
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
-          node-version-file: .tool-versions
+          node-version: ${{ matrix.node-version }}
 
       - name: Install base dependencies
         run: npm ci
@@ -23,8 +25,10 @@ jobs:
       - name: Install target Next.js version
         run: npm install next@${{ matrix.next-version }}
 
-      - name: Next version
-        run: npx next --version
+      - name: Print versions
+        run: |
+          node -v
+          npx next --version
 
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
## 📝 Overview

Added matrix testing for multiple Node.js versions (18, 20, 22) in the CI workflow.

## 🧐 Motivation and Background

To ensure compatibility with multiple active LTS and current versions of Node.js, the workflow was updated to test across these versions in addition to different Next.js versions.

## ✅ Changes

- [x] Added `node-version` to the matrix strategy in `test.yml`
- [x] Replaced `node-version-file` with dynamic `matrix.node-version`
- [x] Renamed step to print both Node.js and Next.js versions

## 💡 Notes / Screenshots

- This results in 9 combinations (3 Node.js versions × 3 Next.js versions) tested in parallel
- Helpful for detecting compatibility issues early

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Verified matrix combinations run correctly in GitHub Actions