### PR TITLE
chore: add from-package option for Next.js version in CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18, 20, 22]
-        next-version: ["14.0.0", "15.0.0", "15.2.4"]
+        next-version: ["14.0.0", "15.0.0", "from-package"]
     steps:
       - uses: actions/checkout@v4
 
@@ -23,7 +23,13 @@ jobs:
         run: npm ci
 
       - name: Install target Next.js version
-        run: npm install next@${{ matrix.next-version }}
+        run: |
+          if [ "${{ matrix.next-version }}" = "from-package" ]; then
+            echo "Using next from package.json"
+          else
+            echo "Installing next@${{ matrix.next-version }}"
+            npm install "next@${{ matrix.next-version }}"
+          fi
 
       - name: Print versions
         run: |


### PR DESCRIPTION
## 📝 Overview

- Added support for using the Next.js version defined in `package.json` by introducing `from-package` as a matrix option in the CI workflow.

## 🧐 Motivation and Background

- Previously, the CI tested only specific hardcoded versions of Next.js.
- Adding `from-package` allows testing against the version the project is currently using, improving coverage and flexibility.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [x] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- This avoids unnecessary reinstallation of Next.js when using the version already declared in `package.json`.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed