### PR TITLE
feat: tag merged PR titles with release version after publishing

### DIFF
--- a/.github/workflows/add-version-to-pr-title.yml
+++ b/.github/workflows/add-version-to-pr-title.yml
@@ -1,0 +1,48 @@
+name: Tag PRs with Release Version
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version"
+        required: true
+        type: string
+
+jobs:
+  tag_prs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get previous tag
+        id: previous_tag
+        run: |
+          prev_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^v${{ inputs.version }}$" | head -n 1)
+          echo "tag=$prev_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Find merged PRs between tags
+        id: find_prs
+        run: |
+          prs=$(git log --pretty=format:"%s" ${{ steps.previous_tag.outputs.tag }}..v${{ inputs.version }} \
+            | grep -v 'chore: bump version' \
+            | grep -oE '#[0-9]+' \
+            | tr -d '#' \
+            | xargs || true)
+          echo "prs=${prs}" >> $GITHUB_OUTPUT
+
+      - name: Tag PR titles with release version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for pr in ${{ steps.find_prs.outputs.prs }}; do
+            title=$(gh pr view $pr --json title -q ".title")
+            if [[ "$title" != *"[v${{ inputs.version }}]"* ]]; then
+              gh pr edit $pr --title "$title [v${{ inputs.version }}]"
+            else
+              echo "PR #$pr already includes version"
+            fi
+          done

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -15,6 +15,9 @@ jobs:
   release:
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/v') && github.event.pull_request.user.login == 'github-actions[bot]'
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      release_sha: ${{ github.sha }}
 
     steps:
       - name: Checkout repo
@@ -52,3 +55,10 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  tag_prs:
+    needs: release
+    uses: ./.github/workflows/add-version-to-pr-title.yml
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## 📝 Overview

- Added a new workflow to automatically tag merged PR titles with the release version after publishing to NPM.

## 😨 Motivation and Background

- Helps track which PRs were included in a given release by appending the release version to their titles.
- Enhances traceability and simplifies release auditing.

## ✅ Changes

- [x] Feature added
  - Added `add-version-to-pr-title.yml` reusable workflow.
  - Integrated the new workflow into `release-on-merge.yml` using `workflow_call` and `workflow_call.inputs`.
  - Extracted and passed version information to the workflow.
  - Parsed merged PRs between tags using Git log.
  - Used GitHub CLI to append version tags to PR titles.

## 💡 Notes / Screenshots

- Handles cases where PRs are already tagged with the version.
- Excludes `chore: bump version` commits from PR tagging process.

## 🗑️ Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed on GitHub Actions with test release