### PR TITLE
refactor: improve readability and type safety in matchPath implementation

### DIFF
--- a/src/rpc/client/match.ts
+++ b/src/rpc/client/match.ts
@@ -4,28 +4,31 @@ import { isCatchAllOrOptional } from "./utils";
 export const matchPath = (paths: string[], dynamicKeys: string[]) => {
   return (path: string) => {
     const basePath = `/${paths.slice(1).join("/")}`;
+
     const regexPattern = replaceDynamicSegments(basePath, {
       optionalCatchAll: "(?:/(.*))?",
       catchAll: "/([^/]+(?:/[^/]+)*)",
       dynamic: "/([^/]+)",
     });
-    // Append /? to match with or without a trailing slash.
+
+    // Add optional trailing slash
     const match = new RegExp(`^${regexPattern}/?$`).exec(path);
     if (!match) return null;
 
-    return dynamicKeys.reduce((acc, key, index) => {
-      const paramKey = key.replace(/^_+/, "");
-      const matchValue = match[index + 1];
-      const paramValue = isCatchAllOrOptional(key)
-        ? matchValue === undefined || matchValue === ""
-          ? undefined
-          : matchValue
-              .split("/")
-              .filter((segment) => segment.length > 0)
-              .map((segment) => decodeURIComponent(segment))
-        : decodeURIComponent(matchValue);
+    return dynamicKeys.reduce<Record<string, string | string[] | undefined>>(
+      (acc, key, index) => {
+        const paramKey = key.replace(/^_+/, "");
+        const matchValue = match[index + 1];
 
-      return { ...acc, [paramKey]: paramValue };
-    }, {});
+        const paramValue = isCatchAllOrOptional(key)
+          ? matchValue === undefined || matchValue === ""
+            ? undefined
+            : matchValue.split("/").filter(Boolean).map(decodeURIComponent)
+          : decodeURIComponent(matchValue);
+
+        return { ...acc, [paramKey]: paramValue };
+      },
+      {}
+    );
   };
 };


### PR DESCRIPTION
## 📝 Overview

- Refactored `matchPath` function to improve readability and type safety.

## 😮 Motivation and Background

- The original implementation had redundant logic and inconsistent formatting, making it harder to read and maintain.
- Added an explicit return type for better clarity and type assurance.
- Simplified logic using `filter(Boolean)` instead of `filter((segment) => segment.length > 0)`.

## ✅ Changes

- [x] Refactored `matchPath` for readability
- [x] Added explicit return type to `reduce`
- [x] Used `filter(Boolean)` for conciseness

## 💡 Notes / Screenshots

- `filter(Boolean)` removes empty strings from the split segments.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed