### PR TITLE
chore: grant pull-requests write permission to reusable workflow

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -61,4 +61,6 @@ jobs:
     uses: ./.github/workflows/add-version-to-pr-title.yml
     with:
       version: ${{ needs.release.outputs.version }}
+    permissions:
+      pull-requests: write
     secrets: inherit


### PR DESCRIPTION
## 📜 Overview

- Granted `pull-requests: write` permission to the reusable workflow call within `release-on-merge.yml`.

## 🧐 Motivation and Background

- The reusable workflow (`add-version-to-pr-title.yml`) attempts to edit PR titles using `gh pr edit`, which requires the `updatePullRequest` GraphQL mutation.
- This mutation requires `pull-requests: write` permission, which was not previously granted in the `release-on-merge.yml` caller workflow.
- Without this permission, the workflow fails with the error: `GraphQL: Resource not accessible by integration`.

## ✅ Changes

- [x] Build-related or tool configuration changes (`chore`)
- [x] Updated `release-on-merge.yml` to explicitly set:

```yaml
    permissions:
      pull-requests: write
```

...for the `tag_prs` job calling the reusable workflow.

## 💡 Notes / Screenshots

- The reusable workflow call now includes the correct permission scope, resolving permission-denied issues.

## 🔄 Testing

- [x] Verified GitHub Actions run without `updatePullRequest` errors.
- [x] Confirmed PR titles are updated with version tag when applicable.