### PR TITLE
feat: support up to 6 chained handlers in MethodRouteDefinition

### DIFF
--- a/src/rpc/server/route-types.ts
+++ b/src/rpc/server/route-types.ts
@@ -149,4 +149,57 @@ export interface MethodRouteDefinition<
     TR1 | TR2 | TR3 | TR4 | TOnErrorResponse,
     TV4
   >;
+
+  // 5 handlers
+  <
+    TV1 extends ValidationSchema = ValidationSchema,
+    TV2 extends ValidationSchema = TV1,
+    TV3 extends ValidationSchema = TV1 & TV2,
+    TV4 extends ValidationSchema = TV1 & TV2 & TV3,
+    TV5 extends ValidationSchema = TV1 & TV2 & TV3 & TV4,
+    TR1 extends RouteResponse = RouteResponse,
+    TR2 extends RouteResponse = RouteResponse,
+    TR3 extends RouteResponse = RouteResponse,
+    TR4 extends RouteResponse = RouteResponse,
+    TR5 extends RequiredRouteResponse = RequiredRouteResponse,
+  >(
+    handler1: Handler<TParams, TQuery, TV1, TR1>,
+    handler2: Handler<TParams, TQuery, TV2, TR2>,
+    handler3: Handler<TParams, TQuery, TV3, TR3>,
+    handler4: Handler<TParams, TQuery, TV4, TR4>,
+    handler5: Handler<TParams, TQuery, TV5, TR5>
+  ): HttpMethodMapping<
+    THttpMethod,
+    TParams,
+    TR1 | TR2 | TR3 | TR4 | TR5 | TOnErrorResponse,
+    TV5
+  >;
+
+  // 6 handlers
+  <
+    TV1 extends ValidationSchema = ValidationSchema,
+    TV2 extends ValidationSchema = TV1,
+    TV3 extends ValidationSchema = TV1 & TV2,
+    TV4 extends ValidationSchema = TV1 & TV2 & TV3,
+    TV5 extends ValidationSchema = TV1 & TV2 & TV3 & TV4,
+    TV6 extends ValidationSchema = TV1 & TV2 & TV3 & TV4 & TV5,
+    TR1 extends RouteResponse = RouteResponse,
+    TR2 extends RouteResponse = RouteResponse,
+    TR3 extends RouteResponse = RouteResponse,
+    TR4 extends RouteResponse = RouteResponse,
+    TR5 extends RouteResponse = RouteResponse,
+    TR6 extends RequiredRouteResponse = RequiredRouteResponse,
+  >(
+    handler1: Handler<TParams, TQuery, TV1, TR1>,
+    handler2: Handler<TParams, TQuery, TV2, TR2>,
+    handler3: Handler<TParams, TQuery, TV3, TR3>,
+    handler4: Handler<TParams, TQuery, TV4, TR4>,
+    handler5: Handler<TParams, TQuery, TV5, TR5>,
+    handler6: Handler<TParams, TQuery, TV6, TR6>
+  ): HttpMethodMapping<
+    THttpMethod,
+    TParams,
+    TR1 | TR2 | TR3 | TR4 | TR5 | TR6 | TOnErrorResponse,
+    TV6
+  >;
 }


### PR DESCRIPTION
## 📝 Overview

- Extended the `MethodRouteDefinition` interface to support up to **6 handlers**.

## 🧐 Motivation and Background

- Previously, the routing method interface supported only up to 4 handlers.
- To enable more flexible and composable route definitions (e.g., middlewares, layered validation, or preprocessing), support for additional handlers was necessary.

## ✅ Changes

- [x] Feature added: 5th and 6th handler function signatures added to `MethodRouteDefinition`

## 💡 Notes / Screenshots

- The structure of validation schemas (`TV1`, `TV2`, ...) is maintained as an intersection (`&`) for cumulative merging.
- Final handler response (`TRx`) is always `RequiredRouteResponse` to ensure a response is returned.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed