### PR TITLE
refactor: extract ContentType, HttpStatusCode, and header types into separate modules

### DIFF
--- a/src/rpc/client/http-method.ts
+++ b/src/rpc/client/http-method.ts
@@ -8,7 +8,7 @@ import type {
   BodyOptions,
   HeadersOptions,
 } from "./types";
-import type { ContentType } from "../server/types";
+import type { ContentType } from "../lib/content-type-types";
 
 const normalizeHeaders = (headers?: HeadersInit): Record<string, string> => {
   const result: Record<string, string> = {};

--- a/src/rpc/client/types.ts
+++ b/src/rpc/client/types.ts
@@ -4,70 +4,16 @@ import type {
   DYNAMIC_PREFIX,
   HTTP_METHOD_FUNC_KEYS,
 } from "../lib/constants";
+import type { ContentType } from "../lib/content-type-types";
+import type { HttpRequestHeaders } from "../lib/http-request-headers-types";
+import type { HttpStatusCode } from "../lib/http-status-code-types";
 import type {
   RouteHandlerResponse,
   RouteResponse,
   ValidationSchema,
 } from "../server/route-types";
-import type {
-  TypedNextResponse,
-  HttpStatusCode,
-  ContentType,
-  ValidationInputFor,
-} from "../server/types";
+import type { TypedNextResponse, ValidationInputFor } from "../server/types";
 import type { NextResponse } from "next/server";
-
-/**
- * Represents HTTP request headers with optional fields.
- * This type includes general request headers, CORS/security-related headers, and client-specific headers.
- */
-type HttpRequestHeaders = Partial<{
-  // General information
-  Accept: string;
-  "Accept-Charset": string;
-  "Accept-Encoding": string;
-  "Accept-Language": string;
-  Authorization: string;
-  "Cache-Control": string;
-  Connection: string;
-  "Content-Length": string;
-  "Content-Type": ContentType;
-  Cookie: string;
-  Date: string;
-  Expect: string;
-  Forwarded: string;
-  From: string;
-  Host: string;
-  "If-Match": string;
-  "If-Modified-Since": string;
-  "If-None-Match": string;
-  "If-Range": string;
-  "If-Unmodified-Since": string;
-  "Max-Forwards": string;
-  Origin: string;
-  Pragma: string;
-  Range: string;
-  Referer: string;
-  TE: string;
-  Trailer: string;
-  "Transfer-Encoding": string;
-  Upgrade: string;
-  "User-Agent": string;
-  Via: string;
-  Warning: string;
-
-  // CORS / Security-related
-  "Access-Control-Request-Method": string;
-  "Access-Control-Request-Headers": string;
-  DNT: string; // Do Not Track
-  "Sec-Fetch-Dest": string;
-  "Sec-Fetch-Mode": string;
-  "Sec-Fetch-Site": string;
-  "Sec-Fetch-User": string;
-  "Sec-CH-UA": string;
-  "Sec-CH-UA-Platform": string;
-  "Sec-CH-UA-Mobile": string;
-}>;
 
 /**
  * Extension of the standard `RequestInit` interface with strongly typed headers.

--- a/src/rpc/lib/content-type-types.ts
+++ b/src/rpc/lib/content-type-types.ts
@@ -1,0 +1,21 @@
+type KnownContentType =
+  | "application/json"
+  | "text/html"
+  | "text/plain"
+  | "application/javascript"
+  | "text/css"
+  | "image/png"
+  | "image/jpeg"
+  | "image/svg+xml"
+  | "application/pdf"
+  | "application/octet-stream"
+  | "multipart/form-data"
+  | "application/x-www-form-urlencoded";
+
+/**
+ * A content type that can be either one of the predefined `KnownContentType` values,
+ * or any other custom string.
+ */
+// Allow KnownContentType values with autocomplete, plus any custom string.
+// (string & {}) keeps literal types while accepting arbitrary strings.
+export type ContentType = KnownContentType | (string & {});

--- a/src/rpc/lib/http-request-headers-types.ts
+++ b/src/rpc/lib/http-request-headers-types.ts
@@ -1,0 +1,53 @@
+import type { ContentType } from "../server";
+
+/**
+ * Represents HTTP request headers with optional fields.
+ * This type includes general request headers, CORS/security-related headers, and client-specific headers.
+ */
+export type HttpRequestHeaders = Partial<{
+  // General information
+  Accept: string;
+  "Accept-Charset": string;
+  "Accept-Encoding": string;
+  "Accept-Language": string;
+  Authorization: string;
+  "Cache-Control": string;
+  Connection: string;
+  "Content-Length": string;
+  "Content-Type": ContentType;
+  Cookie: string;
+  Date: string;
+  Expect: string;
+  Forwarded: string;
+  From: string;
+  Host: string;
+  "If-Match": string;
+  "If-Modified-Since": string;
+  "If-None-Match": string;
+  "If-Range": string;
+  "If-Unmodified-Since": string;
+  "Max-Forwards": string;
+  Origin: string;
+  Pragma: string;
+  Range: string;
+  Referer: string;
+  TE: string;
+  Trailer: string;
+  "Transfer-Encoding": string;
+  Upgrade: string;
+  "User-Agent": string;
+  Via: string;
+  Warning: string;
+
+  // CORS / Security-related
+  "Access-Control-Request-Method": string;
+  "Access-Control-Request-Headers": string;
+  DNT: string; // Do Not Track
+  "Sec-Fetch-Dest": string;
+  "Sec-Fetch-Mode": string;
+  "Sec-Fetch-Site": string;
+  "Sec-Fetch-User": string;
+  "Sec-CH-UA": string;
+  "Sec-CH-UA-Platform": string;
+  "Sec-CH-UA-Mobile": string;
+}>;

--- a/src/rpc/lib/http-response-headers-types.ts
+++ b/src/rpc/lib/http-response-headers-types.ts
@@ -1,0 +1,64 @@
+import type { ContentType } from "./content-type-types";
+
+/**
+ * Represents HTTP response headers with optional fields, parameterized by the content type.
+ * This type includes common headers used for caching, content description, CORS, authentication, security, cookies, redirects, connection, and server information.
+ *
+ * @template TContentType - The specific content type for the `Content-Type` header.
+ */
+export type HttpResponseHeaders<TContentType extends ContentType> = Partial<{
+  // Cache control
+  "Cache-Control": string;
+  Expires: string;
+  ETag: string;
+  "Last-Modified": string;
+
+  // Content information
+  "Content-Type": TContentType;
+  "Content-Length": string;
+  "Content-Encoding": string;
+  "Content-Language": string;
+  "Content-Location": string;
+  "Content-Disposition": string;
+
+  // CORS (Cross-Origin Resource Sharing)
+  "Access-Control-Allow-Origin": string;
+  "Access-Control-Allow-Credentials": string;
+  "Access-Control-Allow-Headers": string;
+  "Access-Control-Allow-Methods": string;
+  "Access-Control-Expose-Headers": string;
+
+  // Authentication
+  "WWW-Authenticate": string;
+  Authorization: string;
+
+  // Security
+  "Strict-Transport-Security": string;
+  "Content-Security-Policy": string;
+  "X-Content-Type-Options": string;
+  "X-Frame-Options": string;
+  "X-XSS-Protection": string;
+  "Referrer-Policy": string;
+  "Permissions-Policy": string;
+  "Cross-Origin-Opener-Policy": string;
+  "Cross-Origin-Embedder-Policy": string;
+  "Cross-Origin-Resource-Policy": string;
+
+  // Cookies
+  "Set-Cookie": string;
+
+  // Redirect
+  Location: string;
+
+  // Connection and communication
+  Connection: string;
+  "Keep-Alive": string;
+  "Transfer-Encoding": string;
+  Upgrade: string;
+  Vary: string;
+
+  // Server information
+  Date: string;
+  Server: string;
+  "X-Powered-By": string;
+}>;

--- a/src/rpc/lib/http-status-code-types.ts
+++ b/src/rpc/lib/http-status-code-types.ts
@@ -1,0 +1,93 @@
+/**
+ * Informational responses (100–199)
+ */
+type InformationalHttpStatusCode = 100 | 101 | 102 | 103;
+
+/**
+ * Successful responses (200–299)
+ */
+export type SuccessfulHttpStatusCode =
+  | 200
+  | 201
+  | 202
+  | 203
+  | 204
+  | 205
+  | 206
+  | 207
+  | 208
+  | 226;
+
+/**
+ * Redirection messages (300–399)
+ */
+export type RedirectionHttpStatusCode =
+  | 300
+  | 301
+  | 302
+  | 303
+  | 304
+  | 305
+  | 306
+  | 307
+  | 308;
+
+/**
+ * Client error responses (400–499)
+ */
+type ClientErrorHttpStatusCode =
+  | 400
+  | 401
+  | 402
+  | 403
+  | 404
+  | 405
+  | 406
+  | 407
+  | 408
+  | 409
+  | 410
+  | 411
+  | 412
+  | 413
+  | 414
+  | 415
+  | 416
+  | 417
+  | 418
+  | 421
+  | 422
+  | 423
+  | 424
+  | 425
+  | 426
+  | 428
+  | 429
+  | 431
+  | 451;
+
+/**
+ * Server error responses (500–599)
+ */
+type ServerErrorHttpStatusCode =
+  | 500
+  | 501
+  | 502
+  | 503
+  | 504
+  | 505
+  | 506
+  | 507
+  | 508
+  | 510
+  | 511;
+
+/**
+ * Http status code (100～599)
+ */
+export type HttpStatusCode =
+  | InformationalHttpStatusCode
+  | SuccessfulHttpStatusCode
+  | RedirectionHttpStatusCode
+  | ClientErrorHttpStatusCode
+  | ServerErrorHttpStatusCode;

--- a/src/rpc/server/create-route-context.ts
+++ b/src/rpc/server/create-route-context.ts
@@ -6,12 +6,14 @@ import type {
   Query,
   Params,
   TypedNextResponse,
-  HttpStatusCode,
-  ContentType,
-  RedirectionHttpStatusCode,
   TypedResponseInit,
   ValidationTarget,
 } from "./types";
+import type { ContentType } from "../lib/content-type-types";
+import type {
+  HttpStatusCode,
+  RedirectionHttpStatusCode,
+} from "../lib/http-status-code-types";
 import type { NextRequest } from "next/server";
 
 export const createRouteContext = <

--- a/src/rpc/server/index.ts
+++ b/src/rpc/server/index.ts
@@ -1,2 +1,4 @@
 export { routeHandlerFactory } from "./route-handler-factory";
-export type { ContentType, HttpStatusCode, TypedNextResponse } from "./types";
+export type { TypedNextResponse } from "./types";
+export type { ContentType } from "../lib/content-type-types";
+export type { HttpStatusCode } from "../lib/http-status-code-types";

--- a/src/rpc/server/types.ts
+++ b/src/rpc/server/types.ts
@@ -1,121 +1,12 @@
 import type { ValidationSchema } from "./route-types";
+import type { ContentType } from "../lib/content-type-types";
+import type { HttpResponseHeaders } from "../lib/http-response-headers-types";
+import type {
+  HttpStatusCode,
+  RedirectionHttpStatusCode,
+  SuccessfulHttpStatusCode,
+} from "../lib/http-status-code-types";
 import type { NextResponse, NextRequest } from "next/server";
-
-type KnownContentType =
-  | "application/json"
-  | "text/html"
-  | "text/plain"
-  | "application/javascript"
-  | "text/css"
-  | "image/png"
-  | "image/jpeg"
-  | "image/svg+xml"
-  | "application/pdf"
-  | "application/octet-stream"
-  | "multipart/form-data"
-  | "application/x-www-form-urlencoded";
-
-/**
- * A content type that can be either one of the predefined `KnownContentType` values,
- * or any other custom string.
- */
-// Allow KnownContentType values with autocomplete, plus any custom string.
-// (string & {}) keeps literal types while accepting arbitrary strings.
-export type ContentType = KnownContentType | (string & {});
-
-/**
- * Informational responses (100–199)
- */
-type InformationalHttpStatusCode = 100 | 101 | 102 | 103;
-
-/**
- * Successful responses (200–299)
- */
-type SuccessfulHttpStatusCode =
-  | 200
-  | 201
-  | 202
-  | 203
-  | 204
-  | 205
-  | 206
-  | 207
-  | 208
-  | 226;
-
-/**
- * Redirection messages (300–399)
- */
-export type RedirectionHttpStatusCode =
-  | 300
-  | 301
-  | 302
-  | 303
-  | 304
-  | 305
-  | 306
-  | 307
-  | 308;
-
-/**
- * Client error responses (400–499)
- */
-type ClientErrorHttpStatusCode =
-  | 400
-  | 401
-  | 402
-  | 403
-  | 404
-  | 405
-  | 406
-  | 407
-  | 408
-  | 409
-  | 410
-  | 411
-  | 412
-  | 413
-  | 414
-  | 415
-  | 416
-  | 417
-  | 418
-  | 421
-  | 422
-  | 423
-  | 424
-  | 425
-  | 426
-  | 428
-  | 429
-  | 431
-  | 451;
-
-/**
- * Server error responses (500–599)
- */
-type ServerErrorHttpStatusCode =
-  | 500
-  | 501
-  | 502
-  | 503
-  | 504
-  | 505
-  | 506
-  | 507
-  | 508
-  | 510
-  | 511;
-
-/**
- * Http status code (100～599)
- */
-export type HttpStatusCode =
-  | InformationalHttpStatusCode
-  | SuccessfulHttpStatusCode
-  | RedirectionHttpStatusCode
-  | ClientErrorHttpStatusCode
-  | ServerErrorHttpStatusCode;
 
 /**
  * Represents the result of an HTTP response status check.
@@ -134,69 +25,6 @@ type HttpStatus<T extends HttpStatusCode> = T extends SuccessfulHttpStatusCode
       ok: false;
       status: Exclude<T, SuccessfulHttpStatusCode>;
     };
-
-/**
- * Represents HTTP response headers with optional fields, parameterized by the content type.
- * This type includes common headers used for caching, content description, CORS, authentication, security, cookies, redirects, connection, and server information.
- *
- * @template TContentType - The specific content type for the `Content-Type` header.
- */
-type HttpResponseHeaders<TContentType extends ContentType> = Partial<{
-  // Cache control
-  "Cache-Control": string;
-  Expires: string;
-  ETag: string;
-  "Last-Modified": string;
-
-  // Content information
-  "Content-Type": TContentType;
-  "Content-Length": string;
-  "Content-Encoding": string;
-  "Content-Language": string;
-  "Content-Location": string;
-  "Content-Disposition": string;
-
-  // CORS (Cross-Origin Resource Sharing)
-  "Access-Control-Allow-Origin": string;
-  "Access-Control-Allow-Credentials": string;
-  "Access-Control-Allow-Headers": string;
-  "Access-Control-Allow-Methods": string;
-  "Access-Control-Expose-Headers": string;
-
-  // Authentication
-  "WWW-Authenticate": string;
-  Authorization: string;
-
-  // Security
-  "Strict-Transport-Security": string;
-  "Content-Security-Policy": string;
-  "X-Content-Type-Options": string;
-  "X-Frame-Options": string;
-  "X-XSS-Protection": string;
-  "Referrer-Policy": string;
-  "Permissions-Policy": string;
-  "Cross-Origin-Opener-Policy": string;
-  "Cross-Origin-Embedder-Policy": string;
-  "Cross-Origin-Resource-Policy": string;
-
-  // Cookies
-  "Set-Cookie": string;
-
-  // Redirect
-  Location: string;
-
-  // Connection and communication
-  Connection: string;
-  "Keep-Alive": string;
-  "Transfer-Encoding": string;
-  Upgrade: string;
-  Vary: string;
-
-  // Server information
-  Date: string;
-  Server: string;
-  "X-Powered-By": string;
-}>;
 
 /**
  * Extension of the standard `ResponseInit` interface with strongly typed status and headers.


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

- Extracted `ContentType`, `HttpStatusCode`, `HttpRequestHeaders`, and `HttpResponseHeaders` type definitions into dedicated files under `src/rpc/lib`.
- Updated imports across client and server modules to use the new modularized type definitions.

## 🤔 Motivation and Background

- Improve modularity and maintainability by separating reusable HTTP-related types from the core server logic.
- Reduce coupling and improve clarity of responsibility in `types.ts` files.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [x] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- File structure after refactor:
  - `content-type-types.ts`
  - `http-status-code-types.ts`
  - `http-request-headers-types.ts`
  - `http-response-headers-types.ts`

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed