### PR TITLE
chore/set-release-target-commit

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           gh release create "v${{ steps.get_version.outputs.version }}" \
             --title "Release v${{ steps.get_version.outputs.version }}" \
+            --target "${{ github.event.pull_request.merge_commit_sha }}" \
             --generate-notes
 
       - name: Publish to npm


### PR DESCRIPTION
## 📝 Overview

- Add `--target` flag with `merge_commit_sha` to the GitHub Actions workflow for more accurate release tagging.

## 😮 Motivation and Background

- Previously, the release was created from the default HEAD which could lead to inconsistencies when using squash merges. This change ensures the tag is attached to the actual merge commit.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated
- [x] Build-related or tool configuration changes

## 💡 Notes / Screenshots

- Uses `${{ github.event.pull_request.merge_commit_sha }}` as the release target.

## 🗒 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed (workflow tested with squash merged PR)