### PR TITLE
test: remove debug console logs from watcher test

### DIFF
--- a/src/rpc/cli/watcher.test.ts
+++ b/src/rpc/cli/watcher.test.ts
@@ -236,9 +236,6 @@ describe("setupWatcher", () => {
     // Ensure the async catch() is executed
     await flushPromises();
 
-    console.log("mockCloseError.mock.calls:", mockCloseError.mock.calls);
-    console.log("logger.error.mock.calls:", logger.error.mock.calls);
-
     expect(mockCloseError).toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalledWith(
       "Failed to close watcher: close fail"


### PR DESCRIPTION
## 📝 Overview

- Removed debug `console.log` statements from `watcher.test.ts`

## 😨 Motivation and Background

- The console logs were used during test debugging and are no longer necessary
- Removing them improves test output clarity and avoids noise in CI logs

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated
- [x] Test updated

## 💡 Notes / Screenshots

- Removed logs:
  ```ts
  console.log("mockCloseError.mock.calls:", mockCloseError.mock.calls);
  console.log("logger.error.mock.calls:", logger.error.mock.calls);
  ```

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed