### PR TITLE
chore: split CI workflow for Node.js and Bun support

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Bun test
 
 on:
   push:
@@ -10,17 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
         next-version: ["14.0.0", "15.0.0", "from-package"]
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
 
       - name: Install base dependencies
-        run: npm ci
+        run: bun install
 
       - name: Install target Next.js version
         run: |
@@ -28,19 +26,19 @@ jobs:
             echo "Using next from package.json"
           else
             echo "Installing next@${{ matrix.next-version }}"
-            npm install "next@${{ matrix.next-version }}"
+            bun add "next@${{ matrix.next-version }}"
           fi
 
       - name: Print versions
         run: |
-          node -v
-          npx next --version
+          bun -v
+          bunx next --version
 
       - name: Lint
-        run: npm run lint
+        run: bun run lint
 
       - name: Build
-        run: npm run build
+        run: bun run build:bun
 
       - name: Test
-        run: npm test
+        run: bun run test

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  bun-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  node-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -1,0 +1,46 @@
+name: Node test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+        next-version: ["14.0.0", "15.0.0", "from-package"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install base dependencies
+        run: npm ci
+
+      - name: Install target Next.js version
+        run: |
+          if [ "${{ matrix.next-version }}" = "from-package" ]; then
+            echo "Using next from package.json"
+          else
+            echo "Installing next@${{ matrix.next-version }}"
+            npm install "next@${{ matrix.next-version }}"
+          fi
+
+      - name: Print versions
+        run: |
+          node -v
+          npx next --version
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rpc4next",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rpc4next",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpc4next",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Inspired by Hono RPC and Pathpida, rpc4next brings a lightweight and intuitive RPC solution to Next.js, making server-client communication seamless",
   "author": "watanabe-1",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
   },
   "scripts": {
     "build": "npm run clean && tsc -p tsconfig.build.json",
+    "build:bun": "npm run clean:bun && tsc -p tsconfig.build.json",
     "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "clean:bun": "bun -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "lint": "eslint \"**/*.ts\"",


### PR DESCRIPTION
## 📝 Overview

- Split the existing CI workflow into two separate workflows: one for Node.js and one for Bun.
- Deleted the unified `.github/workflows/test.yml` file.
- Created new workflow files: `node-test.yml` and `bun-test.yml`.

## 😮 Motivation and Background

- To support both Node.js and Bun in CI testing environments independently.
- Bun uses a different runtime and requires a separate setup (e.g., `bun install`, `bunx`, etc.).
- This separation improves clarity and maintainability of CI workflows.

## ✅ Changes

- [x] Deleted `.github/workflows/test.yml`
- [x] Added `.github/workflows/node-test.yml` for Node.js tests
- [x] Added `.github/workflows/bun-test.yml` for Bun tests
- [x] Added `build:bun` and `clean:bun` scripts to `package.json`

## 💡 Notes / Screenshots

- Node matrix still supports multiple versions (18, 20, 22).
- Next.js versions tested in both Node and Bun workflows: 14.0.0, 15.0.0, or from `package.json`.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed