### PR TITLE
chore: update CLI binary path in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "commander": "^13.1.0"
       },
       "bin": {
-        "rpc4next": "dist/cli/index.js"
+        "rpc4next": "dist/rpc/cli/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.14.1",


### PR DESCRIPTION
## 📝 Overview

- Updated the CLI binary path in `package-lock.json` from `dist/cli/index.js` to `dist/rpc/cli/index.js`.

## 😮 Motivation and Background

- Reflect the correct path of the CLI entry point due to directory restructuring or build output changes.

## ✅ Changes

- [x] Build-related path updated in `package-lock.json`
- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- Ensure the `dist/rpc/cli/index.js` file exists after build to avoid broken CLI references.

## 🗝 Testing

- [ ] `npm run lint` passed
- [ ] `npm run test` passed
- [x] Manual verification completed (e.g., `npx rpc4next --help` works as expected)