### PR TITLE
chore: move bun install step after Next.js version setup in CI workflow

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
 
-      - name: Add target Next.js version
+      - name: Set Next.js version
         run: |
           if [ "${{ matrix.next-version }}" = "from-package" ]; then
             echo "Using next from package.json"
           else
-            echo "Installing next@${{ matrix.next-version }}"
-            bun add "next@${{ matrix.next-version }}"
+            echo "Overwriting package.json to use next@${{ matrix.next-version }}"
+            jq '.dependencies.next = "${{ matrix.next-version }}"' package.json > package.tmp.json && mv package.tmp.json package.json
           fi
 
       - name: Install dependencies

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -17,10 +17,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
 
-      - name: Install base dependencies
-        run: bun install
-
-      - name: Install target Next.js version
+      - name: Add target Next.js version
         run: |
           if [ "${{ matrix.next-version }}" = "from-package" ]; then
             echo "Using next from package.json"
@@ -28,6 +25,9 @@ jobs:
             echo "Installing next@${{ matrix.next-version }}"
             bun add "next@${{ matrix.next-version }}"
           fi
+
+      - name: Install dependencies
+        run: bun install
 
       - name: Print versions
         run: |

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -23,7 +23,8 @@ jobs:
             echo "Using next from package.json"
           else
             echo "Overwriting package.json to use next@${{ matrix.next-version }}"
-            jq '.devDependencies.next = "${{ matrix.next-version }}"' package.json > package.tmp.json && mv package.tmp.json package.json
+            rm -f package-lock.json
+            bun add "next@${{ matrix.next-version }}"
           fi
 
       - name: Install dependencies

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -23,7 +23,7 @@ jobs:
             echo "Using next from package.json"
           else
             echo "Overwriting package.json to use next@${{ matrix.next-version }}"
-            jq '.dependencies.next = "${{ matrix.next-version }}"' package.json > package.tmp.json && mv package.tmp.json package.json
+            jq '.devDependencies.next = "${{ matrix.next-version }}"' package.json > package.tmp.json && mv package.tmp.json package.json
           fi
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "eslint-plugin-unused-imports": "^4.1.4",
     "mock-fs": "^5.5.0",
     "msw": "^2.7.4",
-    "next": "15.3.1",
+    "next": "^14.0.0 || ^15.0.0",
     "prettier": "^3.5.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "eslint-plugin-unused-imports": "^4.1.4",
     "mock-fs": "^5.5.0",
     "msw": "^2.7.4",
-    "next": "^14.0.0 || ^15.0.0",
+    "next": "15.3.1",
     "prettier": "^3.5.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",


### PR DESCRIPTION
## 📝 Overview

- Moved the `bun install` step after setting the desired Next.js version in the Bun CI workflow

## 🧐 Motivation and Background

- Previously, dependencies were installed before potentially overriding the Next.js version, which could result in version mismatch.
- Reordering ensures that `bun install` installs the correct version of Next.js as per matrix configuration.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated
- [x] CI workflow adjusted

## 💡 Notes / Screenshots

- N/A

## 🔄 Testing

- [x] CI passes with all matrix configurations
- [ ] `npm run lint` passed
- [ ] `npm run test` passed
- [x] Manual verification completed