### PR TITLE
chore: add release tag verification and handle empty commits in release workflow

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -49,7 +49,8 @@ jobs:
         run: |
           gh release create "v${{ steps.get_version.outputs.version }}" \
             --title "Release v${{ steps.get_version.outputs.version }}" \
-            --target "${{ github.event.pull_request.merge_commit_sha }}" \
+            --verify-tag \
+            --fail-on-no-commits \
             --generate-notes
 
       - name: Publish to npm


### PR DESCRIPTION
## 📝 Overview

- Updated the GitHub Actions release workflow to include tag verification and fail handling for empty commits.

## 😮 Motivation and Background

- Ensuring the tag exists before attempting to create a release helps avoid runtime errors.
- Failing gracefully when there are no commits to release prevents accidental or empty releases.

## ✅ Changes

- [x] Added `--verify-tag` option to `gh release create`
- [x] Added `--fail-on-no-commits` to prevent empty release creation
- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- The `--verify-tag` flag requires the tag to already exist and be pushed to GitHub.
- No functional code changes—only CI workflow logic is affected.

## 🔄 Testing

- [ ] `npm run lint` passed
- [ ] `npm run test` passed
- [x] Manual verification completed with workflow runs