### PR TITLE
fix: preserve undefined arguments in debounce trailing call

### DIFF
--- a/src/rpc/cli/debounce.ts
+++ b/src/rpc/cli/debounce.ts
@@ -29,12 +29,12 @@ export const debounceOnceRunningWithTrailing = <
 
     timer = setTimeout(() => {
       if (isRunning) {
-        pendingArgs = args ?? [];
+        pendingArgs = args;
 
         return;
       }
 
-      execute(...(args ?? []));
+      execute(...args);
     }, delay);
   };
 };


### PR DESCRIPTION
## 📝 Overview

- Updated the `debounceOnceRunningWithTrailing` utility to preserve `undefined` arguments instead of replacing them with an empty array.

## 🧐 Motivation and Background

- Previously, if the arguments passed to the debounced function were `undefined`, they would be coerced into an empty array, which could cause incorrect behavior in functions that expect `undefined` explicitly.

## ✅ Changes

- [x] Bug fixed

## 💡 Notes / Screenshots

- N/A

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed

