### PR TITLE
chore: add head-branch pattern for test label in labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,6 +27,7 @@ test:
   - changed-files:
       - any-glob-to-any-file: "src/tests/**"
       - any-glob-to-any-file: "**/*.test.*"
+  - head-branch: ["^test/"]
 
 feature:
   - head-branch: ["^feature/", "^feat/"]


### PR DESCRIPTION
## 📝 Overview

- Updated `.github/labeler.yml` to apply the `test` label based on branch name.

## 🧐 Motivation and Background

- Previously, the `test` label was only applied based on file paths.
- This update ensures PRs from branches named like `test/...` are also labeled automatically.

## ✅ Changes

- [x] Added `head-branch: ["^test/"]` condition to the `test` label

## 💡 Notes / Screenshots

- This improves automation in labeling and helps maintain consistent tagging of test-related PRs.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed
