### PR TITLE
refactor: simplify conditional logic for extracting skipped directorypaths

### DIFF
--- a/src/rpc/cli/core/route-scanner.ts
+++ b/src/rpc/cli/core/route-scanner.ts
@@ -202,9 +202,8 @@ export const scanAppDir = (
       if (isSkipDir) {
         // Extract only the inner part inside `{}` from the child output
         const match = childPathStructure.match(/^\s*\{([\s\S]*)\}\s*$/);
-        const childContent = match ? match[1].trim() : "";
-        if (childContent) {
-          pathStructures.push(`${currentIndent}${childContent}`);
+        if (match) {
+          pathStructures.push(`${currentIndent}${match[1].trim()}`);
         }
       } else {
         pathStructures.push(


### PR DESCRIPTION
## 📝 Overview

- Simplified the logic used when extracting skipped directory paths within the `scanAppDir` function in `route-scanner.ts`.

## 🧐 Motivation and Background

- The previous implementation extracted the inner content of matched braces but used an additional variable and conditional.
- The change improves readability and eliminates redundant code.

## ✅ Changes

- [x] Refactored logic in `scanAppDir` to inline the extraction of inner content using a cleaner `if (match)` check.

## 💡 Notes / Screenshots

- The extracted content is still trimmed and appended with correct indentation.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed