### PR TITLE
test: add test for invalid usage of dynamic and static RPC path segments

### DIFF
--- a/src/rpc/client/rpc.test.ts
+++ b/src/rpc/client/rpc.test.ts
@@ -436,6 +436,28 @@ describe("createRpcClient", () => {
     });
   });
 
+  type FalierPathStructure = Endpoint & {
+    _fuga: Endpoint;
+    hoge: Endpoint;
+  };
+
+  describe("Invalid usage patterns", () => {
+    it("throws when a dynamic parameter is called without an argument or when a static path is called as a function", () => {
+      const client = createRpcClient<FalierPathStructure>("");
+
+      // calling dynamic param without argument
+      expect(() => client._fuga(undefined as unknown as string)).toThrow(
+        "An argument is required when calling the function for paramKey: _fuga"
+      );
+
+      // calling static path segment as a function
+      const hoge = client.hoge as unknown as (value: string) => "";
+      expect(() => hoge("")).toThrow(
+        "paramKey: hoge is not a dynamic parameter and cannot be called as a function"
+      );
+    });
+  });
+
   const { POST: _post_1 } = createRouteHandler().post(
     async (rc) => rc.json("json"),
     async (rc) => rc.text("text")

--- a/src/rpc/client/rpc.ts
+++ b/src/rpc/client/rpc.ts
@@ -23,22 +23,28 @@ export const createRpcProxy = <T extends object>(
 ) => {
   const proxy: unknown = new Proxy(
     (value?: string | number) => {
+      const pathKey = paths.at(-1);
+      const paramKey = dynamicKeys.at(-1);
+
       if (value === undefined) {
-        return createRpcProxy(options, [...paths], params, dynamicKeys);
+        throw new Error(
+          `An argument is required when calling the function for paramKey: ${paramKey}`
+        );
       }
 
-      const newKey = paths.at(-1) ?? "";
-      if (isDynamic(newKey)) {
+      if (pathKey && paramKey && isDynamic(pathKey)) {
         // Treat as a dynamic parameter
         return createRpcProxy(
           options,
           [...paths],
-          { ...params, [dynamicKeys.at(-1) ?? ""]: value },
+          { ...params, [paramKey]: value },
           dynamicKeys
         );
       }
 
-      return createRpcProxy(options, [...paths], params, dynamicKeys);
+      throw new Error(
+        `paramKey: ${pathKey} is not a dynamic parameter and cannot be called as a function`
+      );
     },
     {
       get: (_, key: string) => {


### PR DESCRIPTION
## 📝 Overview

- Added a test case to verify that misuse of RPC client paths throws appropriate errors
- Updated `createRpcProxy` to provide clearer error messages when misused

## 🧐 Motivation and Background

- Ensure robust developer experience by explicitly throwing descriptive errors
- Prevent silent failure or confusing behavior when dynamic/static RPC paths are misused

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated
- [x] Test added for invalid dynamic/static path usage
- [x] Error message improvements in `createRpcProxy`

## 💡 Notes / Screenshots

- Error messages now include the `paramKey` to indicate which parameter is required or misused

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed