### PR TITLE
chore: support setup-node from .tool-versions in CI matrix

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -12,14 +12,23 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, tool-versions]
         next-version: ["14.0.0", "15.0.0", "from-package"]
+
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node.js (from matrix)
+        if: matrix.node-version != 'tool-versions'
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Setup Node.js (from .tool-versions)
+        if: matrix.node-version == 'tool-versions'
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .tool-versions
 
       - name: Install base dependencies
         run: npm ci


### PR DESCRIPTION
## 📝 Overview

- Added support for reading Node.js version from `.tool-versions` in GitHub Actions matrix

## 🧐 Motivation and Background

- Enables workflows to align with local development environments that use `.tool-versions`
- Simplifies version management by avoiding duplication between CI and `.tool-versions`

## ✅ Changes

- [x] Updated node version matrix to include `tool-versions`
- [x] Conditionally run `setup-node` with either `node-version` or `node-version-file`

## 💡 Notes / Screenshots

- Uses `if` conditions to determine how to set up Node.js in matrix strategy

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Verified CI workflow runs correctly with `.tool-versions` entry in matrix