### PR TITLE
chore: update Node.js version to 23.8.0 in .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 22
+nodejs 23.8.0
 bun 1.2.10


### PR DESCRIPTION
## 📝 Overview

- Updated the Node.js version in `.tool-versions` from `22` to `23.8.0`

## 🧐 Motivation and Background

- Keeping the development environment up-to-date with the latest stable Node.js version ensures compatibility with newer features and better performance.

## ✅ Changes

- [x] Build-related update: Node.js version in `.tool-versions` changed to `23.8.0`

## 💡 Notes / Screenshots

- Bun version (`1.2.10`) remains unchanged.

## 🔄 Testing

- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] Manual verification completed