### PR TITLE
chore: migrate scripts and tooling to use Bun instead of npm

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,6 @@
 
 ## 🔄 Testing
 
-- [ ] `npm run lint` passed
-- [ ] `npm run test` passed
+- [ ] `bun run lint` passed
+- [ ] `bun run test` passed
 - [ ] Manual verification completed

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -59,7 +59,7 @@ jobs:
         run: bun run lint
 
       - name: Build
-        run: bun run build:bun
+        run: bun run build
 
       - name: Test
         run: bun run test

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # testing
 /coverage
+*.lcov
 
 # next.js
 /.next/
@@ -22,6 +23,14 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# logs
+logs
+_.log
+report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
+
+# bun
+.bun/
+
 # local env files
 .env*.local
 
@@ -31,6 +40,19 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# output
+*.tgz
+
+# caches
+.eslintcache
+.cache
+
+# IntelliJ based IDEs
+.idea
+
+# Finder (MacOS) folder config
+.DS_Store
 
 # git
 generated-prompt.txt

--- a/package.json
+++ b/package.json
@@ -59,10 +59,8 @@
     }
   },
   "scripts": {
-    "build": "npm run clean && tsc -p tsconfig.build.json",
-    "build:bun": "npm run clean:bun && tsc -p tsconfig.build.json",
-    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
-    "clean:bun": "bun -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "build": "bun run clean && tsc -p tsconfig.build.json",
+    "clean": "bun -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage.enabled true",
     "test:ui": "vitest --ui --coverage.enabled true",


### PR DESCRIPTION
## 📝 Overview

- Migrated project tooling from npm to Bun
- Updated script commands in `package.json` to use `bun run` and `bun -e`
- Updated `.gitignore` to include Bun-specific files and common logs
- Updated PR template to reflect Bun usage for linting and testing

## 🧐 Motivation and Background

- Transitioning to Bun for improved performance and unified tooling
- Removing redundant npm-specific commands

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- N/A

## 🔄 Testing

- [ ] `bun run lint` passed
- [ ] `bun run test` passed
- [ ] Manual verification completed