### PR TITLE
chore: switch release PR workflow from Bun to Node.js with npm version bump

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -46,15 +46,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Read bun version from .tool-versions
-        id: bun-version
-        run: |
-          echo "version=$(grep '^bun ' .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          bun-version: "${{ steps.bun-version.outputs.version }}"
+          node-version-file: .tool-versions
 
       - name: Extract version from tag
         id: extract_version
@@ -73,11 +68,8 @@ jobs:
 
       - name: Bump version
         run: |
-          NEW_VERSION="${{ steps.extract_version.outputs.version }}"
-          jq --arg v "$NEW_VERSION" '.version = $v' package.json > package.tmp.json
-          mv package.tmp.json package.json
-          bun install
-          git add package.json bun.lock
+          npm version ${{ steps.extract_version.outputs.version }} --no-git-tag-version
+          git add package.json
 
       - name: Get previous tag
         id: previous_tag


### PR DESCRIPTION
## 📝 Overview

- Migrated release PR workflow from Bun to Node.js
- Replaced custom `jq` version bump with `npm version`

## 🧐 Motivation and Background

- Align version bumping and environment setup with the Node.js ecosystem for better compatibility and maintainability
- Simplify logic by removing dependency on `.tool-versions` for Bun setup

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated
- [x] Build-related change

## 💡 Notes / Screenshots

- Removed setup-bun step and `.tool-versions` parsing
- Now uses `actions/setup-node` with `node-version-file`
- Bumps version via `npm version` and adds only `package.json`

## 🔄 Testing

- [x] `bun run lint` passed (before Bun removal)
- [x] `bun run test` passed (before Bun removal)
- [x] Manual verification completed