### PR TITLE
chore: update coverage condition to use tool-versions in matrix

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -66,14 +66,14 @@ jobs:
 
       - name: Test
         run: |
-          if [ "${{ matrix.node-version }}" = "22" ] && [ "${{ matrix.next-version }}" = "from-package" ]; then
+          if [ "${{ matrix.node-version }}" = "tool-versions" ] && [ "${{ matrix.next-version }}" = "from-package" ]; then
             npm run test:coverage
           else
             npm run test
           fi
 
       - name: Upload coverage
-        if: ${{ matrix.node-version == '22' && matrix.next-version == 'from-package' }}
+        if: ${{ matrix.node-version == 'tool-versions' && matrix.next-version == 'from-package' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage


### PR DESCRIPTION
## 📝 Overview

- Updated the condition in the GitHub Actions workflow to run `test:coverage` and upload artifacts when `node-version` is set to `tool-versions`.

## 🧐 Motivation and Background

- Previously, coverage upload was limited to when `node-version` was `22`. To align with `.tool-versions` and ensure consistency, the condition was updated to use `tool-versions`.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- Feel free to delete this section if not applicable

## 🔄 Testing

- [ ] `bun run lint` passed
- [ ] `bun run test` passed
- [ ] Manual verification completed