### PR TITLE
chore: add Dependabot configuration for Bun ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## 📝 Overview

- Added a new `.github/dependabot.yml` file to enable automatic dependency updates for the Bun ecosystem.

## 🧐 Motivation and Background

- To keep dependencies up-to-date automatically using GitHub's Dependabot, specifically for projects using Bun as the package manager.

## ✅ Changes

- [x] Build-related or tool configuration changes
  - Added `dependabot.yml` with daily update schedule for `bun` package-ecosystem

## 💡 Notes / Screenshots

- This configuration allows Dependabot to monitor and propose updates to `bun.lockb` regularly.

## 🔄 Testing

- [x] Manual verification completed (confirmed syntax and location are correct)
- [ ] `bun run lint` passed
- [ ] `bun run test` passed