### PR TITLE
fix: handle errors in runCli with try-catch and add coverage tests

### DIFF
--- a/src/rpc/cli/cli.test.ts
+++ b/src/rpc/cli/cli.test.ts
@@ -68,4 +68,34 @@ describe("runCli", () => {
       mockLogger
     );
   });
+
+  it("should log error with Error instance and exit", async () => {
+    vi.spyOn(cliHandler, "handleCli").mockImplementation(() => {
+      throw new Error("Something went wrong");
+    });
+
+    const argv = ["node", "script", "src", "types.ts"];
+    runCli(argv);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Unexpected error occurred:Something went wrong"
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("should log error with non-Error and exit", async () => {
+    vi.spyOn(cliHandler, "handleCli").mockImplementation(() => {
+      throw "plain string error";
+    });
+
+    const argv = ["node", "script", "src", "types.ts"];
+    runCli(argv);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Unexpected error occurred:plain string error"
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
 });

--- a/src/rpc/cli/cli.ts
+++ b/src/rpc/cli/cli.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { handleCli } from "./cli-handler";
+import { EXIT_FAILURE } from "./constants";
 import { createLogger } from "./logger";
 import { CliOptions, Logger } from "./types";
 
@@ -22,9 +23,21 @@ export const runCli = (argv: string[], logger: Logger = createLogger()) => {
     )
     .action(
       async (baseDir: string, outputPath: string, options: CliOptions) => {
-        const exitCode = handleCli(baseDir, outputPath, options, logger);
-        if (!options.watch) {
-          process.exit(exitCode as number);
+        try {
+          const exitCode = await handleCli(
+            baseDir,
+            outputPath,
+            options,
+            logger
+          );
+          if (!options.watch) {
+            process.exit(exitCode as number);
+          }
+        } catch (error) {
+          logger.error(
+            `Unexpected error occurred:${error instanceof Error ? error.message : String(error)}`
+          );
+          process.exit(EXIT_FAILURE as number);
         }
       }
     );


### PR DESCRIPTION
## 📝 Overview

- Add error handling to `runCli` using `try-catch`
- Log errors with appropriate messages via `logger`
- Ensure process exits with proper code on failure
- Add tests to cover both `Error` and non-`Error` thrown values

## 🧐 Motivation and Background

- Previously, if `handleCli` threw an error, it could cause an unhandled promise rejection and crash the CLI.
- Ensuring graceful failure and logging improves developer experience and robustness.

## ✅ Changes

- [x] Bug fixed
- [x] Test added

## 💡 Notes / Screenshots

- Error messages are prefixed with `Unexpected error occurred:`
- Supports both `Error` instances and primitive values (like strings)

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed