### PR TITLE
chore: switch to esbuild for JS build and isolate type-only build with tsc

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 *.tsx         text eol=lf
 *.txt         text eol=lf
 *.yml         text eol=lf
+*.lock        text eol=lf
 .code-workspace text eol=lf
 .gitignore    text eol=lf
 .tool-versions    text eol=lf

--- a/build.ts
+++ b/build.ts
@@ -1,0 +1,30 @@
+import { build, BuildOptions } from "esbuild";
+import glob from "fast-glob";
+
+const baseOptions: BuildOptions = {
+  outbase: "src",
+  outdir: "dist",
+  bundle: false,
+  target: "ES2022",
+  format: "esm",
+  minify: true,
+  tsconfig: "tsconfig.build.json",
+};
+
+const entriesForCli = await glob(["src/rpc/cli/**/*.ts", "!src/**/*.test.ts"]);
+await build({
+  ...baseOptions,
+  entryPoints: entriesForCli,
+  platform: "node",
+});
+
+const entriesForNext = await glob([
+  "src/rpc/**/*.ts",
+  "!src/rpc/cli/**",
+  "!src/**/*.test.ts",
+]);
+await build({
+  ...baseOptions,
+  entryPoints: entriesForNext,
+  platform: "neutral",
+});

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@vitest/coverage-v8": "^3.1.1",
         "@vitest/eslint-plugin": "^1.1.43",
         "@vitest/ui": "^3.1.1",
+        "esbuild": "^0.25.2",
         "eslint": "^9.24.0",
         "eslint-config-prettier": "^10.1.2",
         "eslint-plugin-import": "^2.31.0",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ const config = [
       "**/.next",
       "**/eslint.config.mjs",
       "**/vitest.config.ts",
+      "./build.ts",
     ],
   },
   {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typescript",
     "cli"
   ],
+  "type": "module",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -59,7 +60,8 @@
     }
   },
   "scripts": {
-    "build": "bun run clean && tsc -p tsconfig.build.json",
+    "build": "bun run clean && bun build.ts && bun run build:types",
+    "build:types": "tsc -p tsconfig.build-types.json",
     "clean": "bun -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage.enabled true",
@@ -77,6 +79,7 @@
     "@vitest/coverage-v8": "^3.1.1",
     "@vitest/eslint-plugin": "^1.1.43",
     "@vitest/ui": "^3.1.1",
+    "esbuild": "^0.25.2",
     "eslint": "^9.24.0",
     "eslint-config-prettier": "^10.1.2",
     "eslint-plugin-import": "^2.31.0",

--- a/tsconfig.build-types.json
+++ b/tsconfig.build-types.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "declaration": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["node_modules", "src/**/*.test.ts", "src/rpc/cli/**"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,3 @@
 {
-  "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["node_modules", "src/**/*.test.ts"]
+  "extends": "./tsconfig.json"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES6",
+    "target": "ES2022",
     "module": "commonjs",
     "rootDir": "./src/",
     "declaration": true,


### PR DESCRIPTION
## 📝 Overview

- Migrated the build system from `tsc` to `esbuild` for JavaScript output.
- Introduced a dedicated type-only build using `tsc` with `tsconfig.build-types.json`.
- Updated scripts in `package.json` accordingly.

## 🧐 Motivation and Background

- Improve build speed and output size using `esbuild`.
- Separate concerns for JS compilation and type generation.
- Prepare for better ESM support and cleaner build artifacts.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [x] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- `build.ts` uses `fast-glob` to split builds between CLI and Next.js-compatible output.
- Type declarations are now generated with `tsc` using a separate config file.

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed