### PR TITLE
refactor: remove dependency on internal Next.js HTTP method types

### DIFF
--- a/src/rpc/lib/constants.ts
+++ b/src/rpc/lib/constants.ts
@@ -1,4 +1,12 @@
-import { HTTP_METHODS } from "next/dist/server/web/http";
+export const HTTP_METHODS = [
+  "GET",
+  "HEAD",
+  "OPTIONS",
+  "POST",
+  "PUT",
+  "DELETE",
+  "PATCH",
+] as const;
 
 export const OPTIONAL_CATCH_ALL_PREFIX = "_____";
 export const CATCH_ALL_PREFIX = "___";

--- a/src/rpc/lib/types.ts
+++ b/src/rpc/lib/types.ts
@@ -1,1 +1,3 @@
-export type { HTTP_METHOD as HttpMethod } from "next/dist/server/web/http";
+import type { HTTP_METHODS } from "./constants";
+
+export type HttpMethod = (typeof HTTP_METHODS)[number];


### PR DESCRIPTION
## 📝 Overview

- Replaced the use of internal `next/dist/server/web/http` HTTP method types with a local constant and type definition.

## 🧐 Motivation and Background

- Avoid dependency on internal Next.js modules which may change without notice and are not intended for public use.
- Improve maintainability and type safety with a local `HTTP_METHODS` definition.

## ✅ Changes

- [x] Refactored: Defined `HTTP_METHODS` locally in `constants.ts`.
- [x] Refactored: Created a type alias `HttpMethod` using `typeof HTTP_METHODS[number]`.
- [ ] Feature added
- [ ] Bug fixed
- [ ] Documentation updated

## 💡 Notes / Screenshots

- Ensures future compatibility with Next.js updates by avoiding private APIs.

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed