### PR TITLE
refactor: decouple rpcClient and rpcHelper using injectable handler callbacks

### DIFF
--- a/src/rpc/client/index.ts
+++ b/src/rpc/client/index.ts
@@ -1,2 +1,3 @@
-export { createRpcClient, createRpcHelper } from "./rpc";
+export { createRpcClient } from "./rpc-client";
+export { createRpcHelper } from "./rpc-helper";
 export type { Endpoint, ParamsKey, QueryKey, OptionalQueryKey } from "./types";

--- a/src/rpc/client/rpc-client.test.ts
+++ b/src/rpc/client/rpc-client.test.ts
@@ -10,13 +10,13 @@ import {
   expectTypeOf,
   it,
 } from "vitest";
-import { createRpcClient } from "./rpc";
 import {
   ContentType,
   HttpStatusCode,
   routeHandlerFactory,
   TypedNextResponse,
 } from "../server";
+import { createRpcClient } from "./rpc-client";
 import { ParamsKey, Endpoint, QueryKey } from "./types";
 
 const createRouteHandler = routeHandlerFactory();
@@ -447,14 +447,12 @@ describe("createRpcClient", () => {
 
       // calling dynamic param without argument
       expect(() => client._fuga(undefined as unknown as string)).toThrow(
-        "An argument is required when calling the function for paramKey: _fuga"
+        "Missing value for dynamic parameter: _fuga"
       );
 
       // calling static path segment as a function
       const hoge = client.hoge as unknown as (value: string) => "";
-      expect(() => hoge("")).toThrow(
-        "paramKey: hoge is not a dynamic parameter and cannot be called as a function"
-      );
+      expect(() => hoge("")).toThrow("hoge is not dynamic");
     });
   });
 

--- a/src/rpc/client/rpc-client.ts
+++ b/src/rpc/client/rpc-client.ts
@@ -1,0 +1,51 @@
+import { httpMethod } from "./http-method";
+import { makeCreateRpc } from "./rpc";
+import { createUrl } from "./url";
+import { isHttpMethod } from "./utils";
+import type { ClientOptions, DynamicPathProxyAsFunction } from "./types";
+
+/**
+ * Creates an RPC client proxy for making HTTP requests with a strongly typed API.
+ *
+ * @template T - The type defining the RPC endpoint structure.
+ * @param baseUrl - The base URL for the RPC client. This URL will be used as the root for all generated endpoint URLs.
+ * @param options - (Optional) Client options to customize the behavior of the RPC client. These options may include a custom fetch function and default request initialization options.
+ * @returns An object that enables you to dynamically build endpoint URLs and execute HTTP requests (such as GET, POST, DELETE, etc.) with full type support.
+ *
+ * @example
+ * ```ts
+ * import { createRpcClient } from "./rpc";
+ * import type { PathStructure } from "./types";
+ *
+ * // Create an RPC client with a base URL
+ * const client = createRpcClient<PathStructure>("http://localhost:3000");
+ *
+ * // Generate a URL for a dynamic endpoint
+ * const urlResult = client.fuga._foo("test").$url();
+ * console.log(urlResult.path);         // "http://localhost:3000/fuga/test"
+ * console.log(urlResult.relativePath);   // "/fuga/test"
+ * console.log(urlResult.pathname);       // "/fuga/[foo]"
+ * console.log(urlResult.params);         // { foo: "test" }
+ *
+ * // Execute a GET request on an endpoint
+ * const response = await client.api.hoge._foo("test").$get();
+ * console.log(await response.json());    // Expected response: { method: "get" }
+ * ```
+ *
+ * The above example demonstrates how to generate URLs with dynamic segments and how to execute HTTP requests.
+ */
+export const createRpcClient = makeCreateRpc(
+  (key, { paths, params, dynamicKeys, options }) => {
+    if (key === "$url") {
+      return createUrl([...paths], params, dynamicKeys);
+    }
+    if (isHttpMethod(key)) {
+      return httpMethod(key, [...paths], params, dynamicKeys, options);
+    }
+
+    return undefined;
+  }
+) as <T extends object>(
+  baseUrl: string,
+  options?: ClientOptions
+) => DynamicPathProxyAsFunction<T>;

--- a/src/rpc/client/rpc-helper.test.ts
+++ b/src/rpc/client/rpc-helper.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
-import { createRpcHelper } from "./rpc";
-import { Endpoint, ParamsKey } from "./types";
+import { createRpcHelper } from "./rpc-helper";
+import type { Endpoint, ParamsKey } from "./types";
 
 type PathStructure = Endpoint & {
   fuga: Endpoint & {

--- a/src/rpc/client/rpc-helper.ts
+++ b/src/rpc/client/rpc-helper.ts
@@ -1,0 +1,32 @@
+import { matchPath } from "./match";
+import { makeCreateRpc } from "./rpc";
+import type { DynamicPathProxyAsProperty } from "./types";
+
+/**
+ * Creates an RPC helper proxy for dynamic path matching based on a given endpoint structure.
+ *
+ * @template T - The type defining the RPC endpoint structure.
+ *
+ * @returns  An object that provides dynamic RPC helper methods for the defined endpoints.
+ *
+ * @example
+ * ```ts
+ * // Create the RPC helper
+ * const rpcHelper = createRpcHelper<PathStructure>();
+ *
+ * // Use the $match method to extract dynamic parameters from a URL path
+ * const match = rpcHelper.fuga._foo.$match("/fuga/test");
+ * // Expected output: { foo: "test" }
+ *
+ * // If the path does not match, it returns null
+ * const noMatch = rpcHelper.fuga._foo.$match("/hoge/test");
+ * // Expected output: null
+ * ```
+ */
+export const createRpcHelper = makeCreateRpc((key, { paths, dynamicKeys }) => {
+  if (key === "$match") {
+    return matchPath([...paths], dynamicKeys);
+  }
+
+  return undefined;
+}) as <T extends object>() => DynamicPathProxyAsProperty<T>;

--- a/src/rpc/client/rpc-validater.test.ts
+++ b/src/rpc/client/rpc-validater.test.ts
@@ -11,7 +11,7 @@ import {
 } from "vitest";
 import { z } from "zod";
 import { routeHandlerFactory } from "../server";
-import { createRpcClient } from "./rpc";
+import { createRpcClient } from "./rpc-client";
 import { ClientOptions, Endpoint } from "./types";
 import { zodValidator } from "../server/validators/zod";
 

--- a/src/rpc/client/rpc.ts
+++ b/src/rpc/client/rpc.ts
@@ -4,135 +4,61 @@
  * particularly their routing structures and developer experience.
  */
 
-import { httpMethod } from "./http-method";
-import { matchPath } from "./match";
-import { createUrl } from "./url";
-import { isDynamic, isHttpMethod } from "./utils";
-import type {
-  FuncParams,
-  DynamicPathProxyAsFunction,
-  ClientOptions,
-  DynamicPathProxyAsProperty,
-} from "./types";
+import { isDynamic } from "./utils";
+import type { FuncParams, ClientOptions, RpcHandler } from "./types";
 
-export const createRpcProxy = <T extends object>(
+const createProxy = <T>(
+  handler: RpcHandler,
   options: ClientOptions,
-  paths: string[] = [],
-  params: FuncParams = {},
-  dynamicKeys: string[] = []
-) => {
-  const proxy: unknown = new Proxy(
+  paths: string[],
+  params: FuncParams,
+  dynamicKeys: string[]
+): T => {
+  return new Proxy(
     (value?: string | number) => {
-      const pathKey = paths.at(-1);
-      const paramKey = dynamicKeys.at(-1);
-
+      const lastPath = paths.at(-1)!;
+      const lastKey = dynamicKeys.at(-1)!;
       if (value === undefined) {
-        throw new Error(
-          `An argument is required when calling the function for paramKey: ${paramKey}`
-        );
+        throw new Error(`Missing value for dynamic parameter: ${lastKey}`);
       }
-
-      if (pathKey && paramKey && isDynamic(pathKey)) {
-        // Treat as a dynamic parameter
-        return createRpcProxy(
+      if (lastPath && lastKey && isDynamic(lastPath)) {
+        return createProxy(
+          handler,
           options,
           [...paths],
-          { ...params, [paramKey]: value },
+          { ...params, [lastKey]: value },
           dynamicKeys
         );
       }
-
-      throw new Error(
-        `paramKey: ${pathKey} is not a dynamic parameter and cannot be called as a function`
-      );
+      throw new Error(`${lastPath} is not dynamic`);
     },
     {
-      get: (_, key: string) => {
-        if (key === "$url") {
-          return createUrl([...paths], params, dynamicKeys);
-        }
-
-        if (key === "$match") {
-          return matchPath([...paths], dynamicKeys);
-        }
-
-        if (isHttpMethod(key)) {
-          return httpMethod(key, [...paths], params, dynamicKeys, {
-            ...options,
-          });
+      get(_, key: string) {
+        const handled = handler(key, { paths, params, dynamicKeys, options });
+        if (handled !== undefined) {
+          return handled;
         }
 
         if (isDynamic(key)) {
-          // Treat as a dynamic parameter
-          return createRpcProxy(options, [...paths, key], params, [
+          return createProxy(handler, options, [...paths, key], params, [
             ...dynamicKeys,
             key,
           ]);
         }
 
-        return createRpcProxy(options, [...paths, key], params, dynamicKeys);
+        return createProxy(
+          handler,
+          options,
+          [...paths, key],
+          params,
+          dynamicKeys
+        );
       },
     }
-  );
-
-  return proxy as T;
+  ) as T;
 };
 
-/**
- * Creates an RPC client proxy for making HTTP requests with a strongly typed API.
- *
- * @template T - The type defining the RPC endpoint structure.
- * @param baseUrl - The base URL for the RPC client. This URL will be used as the root for all generated endpoint URLs.
- * @param options - (Optional) Client options to customize the behavior of the RPC client. These options may include a custom fetch function and default request initialization options.
- * @returns An object that enables you to dynamically build endpoint URLs and execute HTTP requests (such as GET, POST, DELETE, etc.) with full type support.
- *
- * @example
- * ```ts
- * import { createRpcClient } from "./rpc";
- * import type { PathStructure } from "./types";
- *
- * // Create an RPC client with a base URL
- * const client = createRpcClient<PathStructure>("http://localhost:3000");
- *
- * // Generate a URL for a dynamic endpoint
- * const urlResult = client.fuga._foo("test").$url();
- * console.log(urlResult.path);         // "http://localhost:3000/fuga/test"
- * console.log(urlResult.relativePath);   // "/fuga/test"
- * console.log(urlResult.pathname);       // "/fuga/[foo]"
- * console.log(urlResult.params);         // { foo: "test" }
- *
- * // Execute a GET request on an endpoint
- * const response = await client.api.hoge._foo("test").$get();
- * console.log(await response.json());    // Expected response: { method: "get" }
- * ```
- *
- * The above example demonstrates how to generate URLs with dynamic segments and how to execute HTTP requests.
- */
-export const createRpcClient = <T extends object>(
-  baseUrl: string,
-  options: ClientOptions = {}
-) => createRpcProxy<DynamicPathProxyAsFunction<T>>(options, [baseUrl]);
-
-/**
- * Creates an RPC helper proxy for dynamic path matching based on a given endpoint structure.
- *
- * @template T - The type defining the RPC endpoint structure.
- *
- * @returns  An object that provides dynamic RPC helper methods for the defined endpoints.
- *
- * @example
- * ```ts
- * // Create the RPC helper
- * const rpcHelper = createRpcHelper<PathStructure>();
- *
- * // Use the $match method to extract dynamic parameters from a URL path
- * const match = rpcHelper.fuga._foo.$match("/fuga/test");
- * // Expected output: { foo: "test" }
- *
- * // If the path does not match, it returns null
- * const noMatch = rpcHelper.fuga._foo.$match("/hoge/test");
- * // Expected output: null
- * ```
- */
-export const createRpcHelper = <T extends object>() =>
-  createRpcProxy<DynamicPathProxyAsProperty<T>>({}, ["/"]);
+export const makeCreateRpc =
+  (handler: RpcHandler) =>
+  <T extends object>(base: string = "/", options: ClientOptions = {}) =>
+    createProxy<T>(handler, options, [base], {}, []);

--- a/src/rpc/client/types.ts
+++ b/src/rpc/client/types.ts
@@ -183,3 +183,13 @@ export type DynamicPathProxyAsProperty<T> = Omit<
   },
   QueryKey | OptionalQueryKey | ParamsKey
 >;
+
+export type RpcHandler = (
+  key: string,
+  context: {
+    paths: string[];
+    params: FuncParams;
+    dynamicKeys: string[];
+    options: ClientOptions;
+  }
+) => unknown | undefined;


### PR DESCRIPTION
## 📝 Overview

- Split `createRpcClient` and `createRpcHelper` into separate files
- Introduced `makeCreateRpc` with injectable `RpcHandler` callback
- Replaced hardcoded logic in `rpc.ts` with unified handler-based logic
- Updated related test files, deleted old `rpc.test.ts`

## 🧐 Motivation and Background

- Needed finer-grained control and tree-shakability between `$url`, `$match`, and HTTP method behavior
- Handler injection allows external customization and reduces bundle size

## ✅ Changes

- [x] Refactored: Introduced handler injection architecture
- [x] Removed: `rpc.test.ts` merged into `rpc-client.test.ts`
- [x] Updated: `createRpcClient` and `createRpcHelper` use `makeCreateRpc`

## 💡 Notes / Screenshots

- `RpcHandler` is now the single entry point to control special key behavior like `$url`, `$match`, and HTTP verbs
- Enables cleaner testing and customization

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed
