### PR TITLE
chore: refine glob patterns for build entries to reduce unnecessary bundling

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -12,10 +12,7 @@ const baseOptions: BuildOptions = {
   tsconfig: "tsconfig.build.json",
 };
 
-const entriesForCli = await glob([
-  "src/rpc/cli/**/index.ts",
-  "!src/**/*.test.ts",
-]);
+const entriesForCli = await glob(["src/rpc/cli/index.ts"]);
 const pkg = JSON.parse(readFileSync("./package.json", "utf8"));
 const externals = [
   ...Object.keys(pkg.dependencies || {}),
@@ -32,6 +29,8 @@ await build({
 const entriesForNext = await glob([
   "src/rpc/**/*.ts",
   "!src/rpc/cli/**",
+  "!src/**/types.ts",
+  "!src/**/*-types.ts",
   "!src/**/*.test.ts",
 ]);
 await build({


### PR DESCRIPTION
## 📝 Overview

- Refined the glob patterns used in the `build.ts` script to reduce unnecessary files being included in the build process.

## 😮 Motivation and Background

- The previous patterns included broader directories and test/type files not meant for bundling.
- This change improves build efficiency and output cleanliness.

## ✅ Changes

- [x] Updated glob for CLI entry to a more specific file path
- [x] Added exclusions for `types.ts` and `*-types.ts` files

## 💡 Notes / Screenshots

- N/A

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed