### PR TITLE
chore: import package.json directly for external dependencies instead of fs read

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -1,7 +1,7 @@
 import { build } from "esbuild";
 import type { BuildOptions } from "esbuild";
 import glob from "fast-glob";
-import { readFileSync } from "fs";
+import pkg from "./package.json";
 
 const baseOptions: BuildOptions = {
   outbase: "src",
@@ -13,7 +13,6 @@ const baseOptions: BuildOptions = {
 };
 
 const entriesForCli = await glob(["src/rpc/cli/index.ts"]);
-const pkg = JSON.parse(readFileSync("./package.json", "utf8"));
 const externals = [
   ...Object.keys(pkg.dependencies || {}),
   ...Object.keys(pkg.peerDependencies || {}),


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

- Replaced usage of `readFileSync` for reading `package.json` with direct ESM import to simplify code.

## 😮 Motivation and Background

- Directly importing `package.json` as an ES module is cleaner and avoids manual file reading/parsing.
- This aligns with modern JavaScript/TypeScript practices, especially in ESM environments.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated
- [x] Build-related or tool configuration changes

## 💡 Notes / Screenshots

- Replaced:
  ```ts
  import { readFileSync } from "fs";
  const pkg = JSON.parse(readFileSync("./package.json", "utf8"));
  ```
  with:
  ```ts
  import pkg from "./package.json";
  ```

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed