### PR TITLE
chore: disable Dependabot version updates by setting pull request limit to 0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Disable version updates for npm dependencies
+    open-pull-requests-limit: 0


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

- Disabled Dependabot version updates by setting `open-pull-requests-limit` to `0` in `.github/dependabot.yml`.

## 😮 Motivation and Background

- We want to suppress automatic pull requests from Dependabot for version updates, possibly to manage dependency updates manually or avoid noise.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated
- [x] Tool configuration changed

## 💡 Notes / Screenshots

- This change effectively disables Dependabot from opening any PRs for npm updates.

## 🔄 Testing

- [ ] `bun run lint` passed
- [ ] `bun run test` passed
- [x] Manual verification completed (Confirmed config updated in `.github/dependabot.yml`)