### PR TITLE
chore: enable version updates for package.json in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: increase
     # Disable version updates for npm dependencies
     open-pull-requests-limit: 0


### PR DESCRIPTION
## 📝 Overview

- Updated `.github/dependabot.yml` to ensure `package.json` is updated along with `bun.lock`

## 🧐 Motivation and Background

- Previously, Dependabot was only updating `bun.lock` without modifying `package.json`, resulting in incomplete dependency updates. This change adds `versioning-strategy: increase` to address that.

## ✅ Changes

- [x] Tool configuration updated (`.github/dependabot.yml`)

## 💡 Notes / Screenshots

- `versioning-strategy: increase` ensures that dependency versions in `package.json` are also bumped, not just the lockfile

## 🔄 Testing

- [ ] `bun run lint` passed
- [ ] `bun run test` passed
- [x] Manual verification of correct PR behavior by Dependabot completed