### PR TITLE
chore: move shebang to esbuild banner for CLI entry

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -23,6 +23,9 @@ await build({
   platform: "node",
   bundle: true,
   external: [...externals],
+  banner: {
+    js: "#!/usr/bin/env node",
+  },
 });
 
 const entriesForNext = await glob([

--- a/src/rpc/cli/index.ts
+++ b/src/rpc/cli/index.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { runCli } from "./cli";
 
 runCli(process.argv);


### PR DESCRIPTION
## 📝 Overview

- Moved the shebang (`#!/usr/bin/env node`) from the `src/rpc/cli/index.ts` file into the `esbuild` `banner` option during the build process.

## 💮 Motivation and Background

- Managing the shebang in the source code (`index.ts`) can cause issues when the file is imported elsewhere or bundled.
- Using `esbuild`'s `banner` feature cleanly injects the shebang only into the built output, keeping the source clean and avoiding potential runtime issues.

## ✅ Changes

- [x] Removed direct shebang line from `src/rpc/cli/index.ts`
- [x] Added `banner: { js: '#!/usr/bin/env node' }` to the `esbuild` config when bundling the CLI entry.

## 💡 Notes / Screenshots

- None

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification: Confirmed that the built CLI file starts with the correct shebang and can be executed directly.