### PR TITLE
feat: throw error on unexpected target in zodValidator

### DIFF
--- a/src/rpc/server/validators/zod/zod-validator.test.ts
+++ b/src/rpc/server/validators/zod/zod-validator.test.ts
@@ -344,6 +344,21 @@ describe("zValidator tests", () => {
       expect(res.status).toBe(400);
     });
   });
+
+  it("should throw an error if unexpected target is provided", async () => {
+    const handler = createRouteHandler().post(
+      // @ts-expect-error - force an invalid target for testing
+      zodValidator("invalidTarget", schema),
+      async (rc) => {
+        return rc.text("never reach");
+      }
+    );
+
+    const req = new NextRequest(new URL("http://localhost"));
+    await expect(() =>
+      handler.POST(req, { params: Promise.resolve({}) })
+    ).rejects.toThrowError(new Error("Unexpected target: invalidTarget"));
+  });
 });
 
 describe("zValidator type definitions", () => {

--- a/src/rpc/server/validators/zod/zod-validator.ts
+++ b/src/rpc/server/validators/zod/zod-validator.ts
@@ -82,6 +82,8 @@ export const zodValidator = <
       if (target === "cookies") {
         return await getCookiesObject();
       }
+
+      throw new Error(`Unexpected target: ${target satisfies never}`);
     })();
 
     const result = await schema.safeParseAsync(value);


### PR DESCRIPTION
## 📝 Overview

- Added error handling for unexpected target values in `zodValidator`.
- Implemented a corresponding test to ensure the error is properly thrown.

## 🧐 Motivation and Background

- Previously, passing an unexpected target value to `zodValidator` would not explicitly throw an error, potentially leading to unclear behavior.
- This change enforces strict behavior and improves robustness by immediately throwing a descriptive error when an invalid target is encountered.

## ✅ Changes

- [x] Feature added: Throw an error when an unexpected target is provided to `zodValidator`.
- [x] Test added: Verify that the correct error is thrown for invalid target values.

## 💡 Notes / Screenshots

- The error message format is: `Unexpected target: <target>`
- Used TypeScript `satisfies never` to enforce type-level correctness.

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed