### PR TITLE
chore: add typecheck step to workflows and define typecheck script

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -55,6 +55,9 @@ jobs:
           bun -v
           bunx next --version
 
+      - name: Typecheck
+        run: bun run typecheck
+
       - name: Lint
         run: bun run lint
 

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -58,6 +58,9 @@ jobs:
           node -v
           bun next --version
 
+      - name: Typecheck
+        run: bun run typecheck
+
       - name: Lint
         run: bun run lint
 

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Typecheck
+        run: bun run typecheck
+
       - name: Lint
         run: bun run lint
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "test:ui": "vitest --ui --coverage.enabled true",
     "test:watch": "vitest --watch",
     "lint": "eslint \"**/*.ts\"",
-    "lint:fix": "eslint \"**/*.ts\" --fix"
+    "lint:fix": "eslint \"**/*.ts\" --fix",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "chalk": "^5.4.1",


### PR DESCRIPTION
## 📝 Overview

- Added a `typecheck` step to `.github/workflows/bun-test.yml`, `.github/workflows/node-test.yml`, and `.github/workflows/release-on-merge.yml`.
- Defined a new `typecheck` script (`tsc --noEmit`) in `package.json`.

## 👨‍🎓 Motivation and Background

- To ensure type safety at CI level by performing TypeScript type checks in addition to linting and testing.
- Prevent merging PRs with type errors.

## ✅ Changes

- [x] Added `Typecheck` step in `bun-test.yml`, `node-test.yml`, and `release-on-merge.yml` workflows.
- [x] Added `"typecheck": "tsc --noEmit"` script to `package.json`.

## 💡 Notes / Screenshots

- `typecheck` runs before `lint` step in workflows.
- No changes were made to the existing `lint` and `test` steps.

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed (workflows ran successfully with type checking included)

---