### PR TITLE
chore: enforce spaced-comment rule with exceptions for license and reference comments

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,6 +81,14 @@ const config = [
         "error",
         { blankLine: "always", prev: "*", next: "return" },
       ],
+      "spaced-comment": [
+        "error",
+        "always",
+        {
+          exceptions: ["-"],
+          markers: ["!", "/"],
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

- Enforced the `spaced-comment` ESLint rule to require a space after `//`
- Allowed exceptions for license comments (`/*!`) and TypeScript reference comments (`///`)

## 💪 Motivation and Background

- Improve code consistency by enforcing a space after `//` comments
- Avoid affecting special comments like license headers and TypeScript triple-slash references

## ✅ Changes

- [x] Feature added (new ESLint rule configuration)
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- Configured `spaced-comment` rule with:
  - `exceptions: ["-"]` (to allow visual separators like `//-----`)
  - `markers: ["!", "/"]` (to allow `/*!` and `///` comments)

## 🔄 Testing

- [x] `bun run lint` passed
- [ ] `bun run test` passed
- [x] Manual verification completed