### PR TITLE
docs: update Hono project link in validator.ts file header

### DIFF
--- a/src/rpc/server/validators/validator.ts
+++ b/src/rpc/server/validators/validator.ts
@@ -1,5 +1,5 @@
 /*!
- * Portions of this code are based on the Hono project (https://github.com/honojs/middleware/tree/main/packages/zod-validator),
+ * Portions of this code are based on the Hono project (https://github.com/honojs/hono),
  * originally created by Yusuke Wada (https://github.com/yusukebe) and developed with
  * contributions from the Hono community.
  * This code has been adapted and modified for this project.


### PR DESCRIPTION
## 📝 Overview

- Updated the documentation comment in `validator.ts`.
- Changed the Hono project link from `https://github.com/honojs/middleware/tree/main/packages/zod-validator` to `https://github.com/honojs/hono`.

## 👨‍🎓 Motivation and Background

- The previous link pointed to a specific package in the Hono middleware repository.
- Hono has since restructured its repository, and the main project link is now more appropriate.
- Keeping documentation accurate and up-to-date is important for clarity and maintenance.

## ✅ Changes

- [ ] Documentation updated

## 💡 Notes / Screenshots

- No visual changes or screenshots necessary.
- This is purely a comment update.

## 🔄 Testing

- [ ] `bun run lint` passed
- [ ] `bun run test` passed
- [ ] Manual verification completed (Confirmed the comment update is correct)