### PR TITLE
chore: add head-branch pattern for docs label in labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,6 +22,7 @@ docs:
   - changed-files:
       - any-glob-to-any-file: "docs/**"
       - any-glob-to-any-file: "**/*.md"
+  - head-branch: ["^docs/"]
 
 test:
   - changed-files:


### PR DESCRIPTION
## 📝 Overview

- Updated `.github/labeler.yml` to improve labeling automation.
- Added a `head-branch` pattern to automatically apply the `docs` label when a branch name starts with `docs/`.

## 👨‍💻 Motivation and Background

- Previously, only changes to specific files (`docs/**`, `**/*.md`) triggered the `docs` label.
- Adding a `head-branch` pattern improves the labeling workflow, ensuring that branches dedicated to documentation updates are consistently labeled without requiring file changes.

## ✅ Changes

- [x] Updated labeler configuration to add:
  ```yaml
  docs:
    - head-branch: ["^docs/"]
  ```

## 💡 Notes / Screenshots

- None

## 🔄 Testing

- [ ] `bun run lint` passed
- [ ] `bun run test` passed
- [x] Manual verification completed
  - Confirmed that opening a PR from a branch named `docs/xxx` now correctly applies the `docs` label.