### PR TITLE
refactor: rename validateCallBack to validateHandler for clarity

### DIFF
--- a/src/rpc/server/validators/validator.ts
+++ b/src/rpc/server/validators/validator.ts
@@ -28,7 +28,7 @@ export const validator = <
 >() => {
   return <TTypedNextResponse extends TypedNextResponse>(
     target: TValidationTarget,
-    validateCallBack: (
+    validateHandler: (
       value: object,
       routeContext: RouteContext<TParams, TQuery, TValidationSchema>
     ) => Promise<ValidatedData | TTypedNextResponse>
@@ -53,7 +53,7 @@ export const validator = <
         throw new Error(`Unexpected target: ${target satisfies never}`);
       })();
 
-      const result = await validateCallBack(value, rc);
+      const result = await validateHandler(value, rc);
 
       if (result instanceof Response) {
         return result;


### PR DESCRIPTION
## 📝 Overview

- Renamed the `validateCallBack` parameter to `validateHandler` in `validator.ts` for better clarity and consistency.

## 💪 Motivation and Background

- The previous name `validateCallBack` was too generic and did not clearly express its role.
- `validateHandler` better reflects that the function is responsible for handling validation logic and returning either validated data or an error response.

## ✅ Changes

- [x] Refactored `validateCallBack` to `validateHandler`

## 💡 Notes / Screenshots

- No functional changes, only naming for better readability.

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed