### PR TITLE
refactor: rename generatePages to generatePathStructure for clarity

### DIFF
--- a/src/rpc/cli/core/generate-path-structure.test.ts
+++ b/src/rpc/cli/core/generate-path-structure.test.ts
@@ -9,7 +9,7 @@ import {
   TYPE_KEY_PARAMS,
   TYPE_END_POINT,
 } from "./constants";
-import { generatePages } from "./generate-path-structure";
+import { generatePathStructure } from "./generate-path-structure";
 
 const scanAppDir = vi.hoisted(() => vi.fn());
 vi.mock("./route-scanner", () => ({
@@ -26,7 +26,7 @@ mock({
   "/[hoge]": { bar: { "route.ts": "dummy content" } },
 });
 
-describe("generatePages", () => {
+describe("generatePathStructure", () => {
   it("should generate correct type definitions and imports", () => {
     scanAppDir.mockReturnValue({
       pathStructure: `{ home: ${TYPE_END_POINT}, user: { id: ${TYPE_KEY_PARAMS} }, ${TYPE_KEY_QUERY}, ${TYPE_KEY_OPTIONAL_QUERY}}`,
@@ -47,7 +47,10 @@ describe("generatePages", () => {
 
     const outputPath = "./output";
     const baseDir = "./base";
-    const { pathStructure, paramsTypes } = generatePages(outputPath, baseDir);
+    const { pathStructure, paramsTypes } = generatePathStructure(
+      outputPath,
+      baseDir
+    );
 
     const expectedImports =
       `import type { ${TYPE_END_POINT} ,${TYPE_KEY_OPTIONAL_QUERY} ,${TYPE_KEY_PARAMS} ,${TYPE_KEY_QUERY} } from "${RPC4NEXT_CLIENT_IMPORT_PATH}"${STATEMENT_TERMINATOR}${NEWLINE}` +
@@ -75,7 +78,10 @@ describe("generatePages", () => {
 
     const outputPath = "./output";
     const baseDir = "./base";
-    const { pathStructure, paramsTypes } = generatePages(outputPath, baseDir);
+    const { pathStructure, paramsTypes } = generatePathStructure(
+      outputPath,
+      baseDir
+    );
 
     const expectedImports = `import type { ${TYPE_END_POINT} } from "${RPC4NEXT_CLIENT_IMPORT_PATH}"${STATEMENT_TERMINATOR}${NEWLINE}${NEWLINE}`;
     const expectedTypeDefinition = `export type PathStructure = { dashboard: ${TYPE_END_POINT} }${STATEMENT_TERMINATOR}`;

--- a/src/rpc/cli/core/generate-path-structure.ts
+++ b/src/rpc/cli/core/generate-path-structure.ts
@@ -7,7 +7,7 @@ import {
 import { scanAppDir } from "./route-scanner";
 import { createImport } from "./type-utils";
 
-export const generatePages = (outputPath: string, baseDir: string) => {
+export const generatePathStructure = (outputPath: string, baseDir: string) => {
   const { pathStructure, imports, paramsTypes } = scanAppDir(
     outputPath,
     baseDir

--- a/src/rpc/cli/generator.test.ts
+++ b/src/rpc/cli/generator.test.ts
@@ -26,7 +26,7 @@ describe("generate", () => {
   });
 
   it("should generate types without params file", () => {
-    vi.spyOn(generatePathStructure, "generatePages").mockReturnValue({
+    vi.spyOn(generatePathStructure, "generatePathStructure").mockReturnValue({
       pathStructure: "generated-type-content",
       paramsTypes: [],
     });
@@ -44,7 +44,7 @@ describe("generate", () => {
       event: "generate",
     });
 
-    expect(generatePathStructure.generatePages).toHaveBeenCalledWith(
+    expect(generatePathStructure.generatePathStructure).toHaveBeenCalledWith(
       outputPath,
       baseDir
     );
@@ -67,7 +67,7 @@ describe("generate", () => {
   });
 
   it("should generate types and params files when paramsFileName is provided", () => {
-    vi.spyOn(generatePathStructure, "generatePages").mockReturnValue({
+    vi.spyOn(generatePathStructure, "generatePathStructure").mockReturnValue({
       pathStructure: "generated-type-content",
       paramsTypes: [
         { paramsType: "params-type-1", dirPath: "dir1" },
@@ -88,7 +88,7 @@ describe("generate", () => {
       event: "generate",
     });
 
-    expect(generatePathStructure.generatePages).toHaveBeenCalledWith(
+    expect(generatePathStructure.generatePathStructure).toHaveBeenCalledWith(
       outputPath,
       baseDir
     );

--- a/src/rpc/cli/generator.ts
+++ b/src/rpc/cli/generator.ts
@@ -5,7 +5,7 @@ import {
   SUCCESS_PAD_LENGTH,
   SUCCESS_INDENT_LEVEL,
 } from "./constants";
-import { generatePages } from "./core/generate-path-structure";
+import { generatePathStructure } from "./core/generate-path-structure";
 import { relativeFromRoot } from "./core/path-utils";
 import { padMessage } from "./logger";
 import type { Logger } from "./types";
@@ -23,7 +23,10 @@ export const generate = ({
 }) => {
   logger.info("Generating types...", { event: "generate" });
 
-  const { pathStructure, paramsTypes } = generatePages(outputPath, baseDir);
+  const { pathStructure, paramsTypes } = generatePathStructure(
+    outputPath,
+    baseDir
+  );
 
   fs.writeFileSync(outputPath, pathStructure);
   logger.success(


### PR DESCRIPTION
## 📝 Overview

- Renamed `generatePages` to `generatePathStructure` across the codebase.
- Updated all imports, function calls, test descriptions, and mocks accordingly.

## 🔨 Motivation and Background

- The original function name `generatePages` was not fully representative of its actual purpose.
- The function generates **path structure types** for the Next.js App Router, not pages themselves.
- Renaming improves clarity, maintainability, and intuitiveness for future contributors.

## ✅ Changes

- [x] Refactored function name `generatePages` to `generatePathStructure`.
- [x] Updated imports in `generator.ts`, `generate-path-structure.test.ts`, and `generator.test.ts`.
- [x] Updated test descriptions and spy/mocks related to the renamed function.

## 💡 Notes / Screenshots

- Branch name: `refactor/rename-generate-pages-to-generate-path-structure`
- Commit message: `refactor: rename generatePages to generatePathStructure for clarity`

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed