### PR TITLE
chore: update test coverage reporting settings

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -21,3 +21,5 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
       - name: "Report Coverage"
         uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          comment-on: pr,commit

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "json", "json-summary"],
+      reportOnFailure: true,
       reportsDirectory: "./coverage",
       include: ["src/**/*.ts"],
       exclude: [


### PR DESCRIPTION
## 📝 Overview

- Updated test coverage reporting settings in GitHub Actions and Vitest configuration.

## 💮 Motivation and Background

- Improve visibility and reliability of test coverage reporting.
- Ensure coverage reports are generated and commented both on PRs and commits.
- Enable reporting even if tests fail, to help with debugging.

## ✅ Changes

- [x] Updated `.github/workflows/test-coverage.yml` to set `comment-on: pr,commit` for `davelosert/vitest-coverage-report-action`.
- [x] Updated `vitest.config.ts` to add `reportOnFailure: true` under coverage options.

## 💡 Notes / Screenshots

- No visual changes.
- These updates help ensure coverage information is always available in CI.

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification: Confirmed coverage comments are posted on PRs and commits.