### PR TITLE
chore: simplify Bun setup by using bun-version-file option

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -16,21 +16,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine Bun version
-        id: bun-version
-        run: |
-          if [ "${{ matrix.bun-version }}" = "tool-versions" ]; then
-            version=$(grep '^bun ' .tool-versions | awk '{print $2}')
-          else
-            version="${{ matrix.bun-version }}"
-          fi
-          echo "Resolved Bun version: $version"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Setup Bun
+      - name: Setup Bun (from matrix)
+        if: matrix.bun-version != 'tool-versions'
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "${{ steps.bun-version.outputs.version }}"
+          bun-version: ${{ matrix.bun-version }}
+
+      - name: Setup Bun (from .tool-versions)
+        if: matrix.bun-version == 'tool-versions'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .tool-versions
 
       - name: Install base dependencies
         run: |

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -30,15 +30,10 @@ jobs:
         with:
           node-version-file: .tool-versions
 
-      - name: Read bun version from .tool-versions
-        id: bun-version
-        run: |
-          echo "version=$(grep '^bun ' .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "${{ steps.bun-version.outputs.version }}"
+          bun-version-file: .tool-versions
 
       - name: Install base dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -30,15 +30,10 @@ jobs:
           node-version-file: .tool-versions
           registry-url: https://registry.npmjs.org/
 
-      - name: Read bun version from .tool-versions
-        id: bun-version
-        run: |
-          echo "version=$(grep '^bun ' .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "${{ steps.bun-version.outputs.version }}"
+          bun-version-file: .tool-versions
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## 📝 Overview

- Simplified Bun setup in GitHub Actions workflows by removing manual version extraction.
- Used `bun-version-file` option from `oven-sh/setup-bun@v2` directly.

## 💪 Motivation and Background

- The previous setup manually read the Bun version from `.tool-versions` using shell commands.
- `oven-sh/setup-bun@v2` supports `bun-version-file`, allowing cleaner and more maintainable workflows.

## ✅ Changes

- [x] Removed manual `bun-version` step using `grep` and `awk`.
- [x] Updated `bun-test.yml`, `node-test.yml`, and `release-on-merge.yml` to use `bun-version-file: .tool-versions`.
- [x] Adjusted matrix-based setup to conditionally use `bun-version` or `bun-version-file`.

## 💡 Notes / Screenshots

- Workflows are now shorter and easier to maintain.
- Behavior remains the same, using the Bun version specified in `.tool-versions`.

## 🗑️ Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed on GitHub Actions runs