### PR TITLE
refactor: narrow valid method argument type and adjust test typings

### DIFF
--- a/src/rpc/server/route-context.test.ts
+++ b/src/rpc/server/route-context.test.ts
@@ -37,7 +37,7 @@ describe("createRouteContext", () => {
       "body" as ValidationTarget,
       { name: "John" } as unknown as ValidatedData
     );
-    expect(context.req.valid("body" as ValidationTarget)).toEqual({
+    expect(context.req.valid("body" as never)).toEqual({
       name: "John",
     });
   });

--- a/src/rpc/server/types.ts
+++ b/src/rpc/server/types.ts
@@ -131,7 +131,7 @@ export interface RouteContext<
      * @returns The validation result of the target.
      */
     valid: <TValidationTarget extends ValidationTarget>(
-      target: TValidationTarget
+      target: Extract<TValidationTarget, keyof TValidationSchema["output"]>
     ) => ValidationOutputFor<TValidationTarget, TValidationSchema>;
 
     /**

--- a/src/rpc/server/validators/validator.test.ts
+++ b/src/rpc/server/validators/validator.test.ts
@@ -135,7 +135,10 @@ describe("validator", () => {
           async (v) => schema2.parseAsync(v) as unknown as ValidatedData
         ),
         async (rc) =>
-          rc.json({ p: rc.req.valid("params"), q: rc.req.valid("query") })
+          rc.json({
+            p: rc.req.valid("params" as never),
+            q: rc.req.valid("query" as never),
+          })
       );
 
       const res = await handler.POST(
@@ -193,7 +196,7 @@ describe("validator", () => {
 
           return parsed.data as unknown as ValidatedData;
         }),
-        async (rc) => rc.json({ body: rc.req.valid("json") })
+        async (rc) => rc.json({ body: rc.req.valid("json" as never) })
       );
 
       const res = await handler.POST(
@@ -226,7 +229,7 @@ describe("validator", () => {
 
           return parsed.data as unknown as ValidatedData;
         }),
-        async (rc) => rc.json({ header: rc.req.valid("headers") })
+        async (rc) => rc.json({ header: rc.req.valid("headers" as never) })
       );
 
       const res = await handler.POST(
@@ -278,7 +281,7 @@ describe("validator", () => {
 
           return parsed.data as unknown as ValidatedData;
         }),
-        async (rc) => rc.json({ cookie: rc.req.valid("cookies") })
+        async (rc) => rc.json({ cookie: rc.req.valid("cookies" as never) })
       );
 
       const res = await handler.POST(


### PR DESCRIPTION
## 📝 Overview

- Narrowed the type of the `valid` method's argument to ensure it only accepts keys that exist in the `output` of `ValidationSchema`.
- Adjusted test files to explicitly cast the argument to `never` where necessary to match the stricter typing.

## 🔎 Motivation and Background

- Previously, the `valid` method accepted any `ValidationTarget`, which could lead to incorrect usage.
- By narrowing the type, it ensures only valid keys are passed, improving type safety and preventing potential runtime issues.
- Tests needed minor updates because their typings became stricter with this change.

## ✅ Changes

- [x] Refactored `RouteContext` interface to narrow `valid` argument type.
- [x] Updated related test cases to add `as never` where necessary.

## 💡 Notes / Screenshots

- No changes to runtime behavior.
- This change purely strengthens type checking at compile time.

## 📄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed