### PR TITLE
feat: add HttpMethod typing to handler, validator, and validation targets for improved type safety

### DIFF
--- a/src/rpc/server/handler.test.ts
+++ b/src/rpc/server/handler.test.ts
@@ -2,13 +2,16 @@ import { describe, it, expect, expectTypeOf } from "vitest";
 import { createHandler } from "./handler";
 import type { Handler, ValidationSchema } from "./route-types";
 import type { Params, Query, RouteContext, TypedNextResponse } from "./types";
+import type { HttpMethod } from "../lib/types";
 
 describe("createHandler", () => {
   it("should return the same handler function", () => {
     const handler = async (c: RouteContext) => {
       return c.text("test");
     };
-    const result = createHandler<Params, Query, ValidationSchema>()(handler);
+    const result = createHandler<HttpMethod, Params, Query, ValidationSchema>()(
+      handler
+    );
 
     expect(result).toBe(handler);
   });
@@ -16,13 +19,17 @@ describe("createHandler", () => {
 
 describe("createHandler type definitions", () => {
   it("should infer types correctly", async () => {
-    const _handler = createHandler<Params, Query, ValidationSchema>()(async (
-      c
-    ) => {
+    const _handler = createHandler<
+      HttpMethod,
+      Params,
+      Query,
+      ValidationSchema
+    >()(async (c) => {
       return c.text("test");
     });
 
     type ExpectedHandlerType = Handler<
+      HttpMethod,
       Params,
       Query,
       ValidationSchema,

--- a/src/rpc/server/handler.ts
+++ b/src/rpc/server/handler.ts
@@ -1,14 +1,22 @@
 import type { ValidationSchema, RouteResponse, Handler } from "./route-types";
 import type { Params, Query } from "./types";
+import type { HttpMethod } from "../lib/types";
 
 // I want to use currying so that the return value can be inferred.
 export const createHandler = <
+  THttpMethod extends HttpMethod,
   TParams extends Params,
   TQuery extends Query,
   TValidationSchema extends ValidationSchema,
 >() => {
   return <TRouteResponse extends RouteResponse>(
-    handler: Handler<TParams, TQuery, TValidationSchema, TRouteResponse>
+    handler: Handler<
+      THttpMethod,
+      TParams,
+      TQuery,
+      TValidationSchema,
+      TRouteResponse
+    >
   ) => {
     return handler;
   };

--- a/src/rpc/server/route-handler-factory.ts
+++ b/src/rpc/server/route-handler-factory.ts
@@ -17,10 +17,11 @@ import type { HttpMethod } from "../lib/types";
 import type { NextRequest } from "next/server";
 
 const composeHandlersWithError = <
+  THttpMethod extends HttpMethod,
   TParams extends Params,
   TQuery extends Query,
   TValidationSchema extends ValidationSchema,
-  THandlers extends Handler<TParams, TQuery, TValidationSchema>[],
+  THandlers extends Handler<THttpMethod, TParams, TQuery, TValidationSchema>[],
   TOnErrorResponse extends RequiredRouteResponse,
 >(
   handlers: THandlers,

--- a/src/rpc/server/route-types.ts
+++ b/src/rpc/server/route-types.ts
@@ -32,6 +32,7 @@ export interface ValidationSchema {
 }
 
 export type Handler<
+  _THttpMethod extends HttpMethod,
   TParams = Params,
   TQuery = Query,
   TValidationSchema extends ValidationSchema = ValidationSchema,
@@ -95,7 +96,7 @@ export interface MethodRouteDefinition<
     TV1 extends ValidationSchema = ValidationSchema,
     TR1 extends RequiredRouteResponse = RequiredRouteResponse,
   >(
-    handler: Handler<TParams, TQuery, TV1, TR1>
+    handler: Handler<THttpMethod, TParams, TQuery, TV1, TR1>
   ): HttpMethodMapping<THttpMethod, TParams, TR1 | TOnErrorResponse, TV1>;
 
   // 2 handlers
@@ -105,8 +106,8 @@ export interface MethodRouteDefinition<
     TR1 extends RouteResponse = RouteResponse,
     TR2 extends RequiredRouteResponse = RequiredRouteResponse,
   >(
-    handler1: Handler<TParams, TQuery, TV1, TR1>,
-    handler2: Handler<TParams, TQuery, TV2, TR2>
+    handler1: Handler<THttpMethod, TParams, TQuery, TV1, TR1>,
+    handler2: Handler<THttpMethod, TParams, TQuery, TV2, TR2>
   ): HttpMethodMapping<THttpMethod, TParams, TR1 | TR2 | TOnErrorResponse, TV2>;
 
   // 3 handlers
@@ -118,9 +119,9 @@ export interface MethodRouteDefinition<
     TR2 extends RouteResponse = RouteResponse,
     TR3 extends RequiredRouteResponse = RequiredRouteResponse,
   >(
-    handler1: Handler<TParams, TQuery, TV1, TR1>,
-    handler2: Handler<TParams, TQuery, TV2, TR2>,
-    handler3: Handler<TParams, TQuery, TV3, TR3>
+    handler1: Handler<THttpMethod, TParams, TQuery, TV1, TR1>,
+    handler2: Handler<THttpMethod, TParams, TQuery, TV2, TR2>,
+    handler3: Handler<THttpMethod, TParams, TQuery, TV3, TR3>
   ): HttpMethodMapping<
     THttpMethod,
     TParams,
@@ -139,10 +140,10 @@ export interface MethodRouteDefinition<
     TR3 extends RouteResponse = RouteResponse,
     TR4 extends RequiredRouteResponse = RequiredRouteResponse,
   >(
-    handler1: Handler<TParams, TQuery, TV1, TR1>,
-    handler2: Handler<TParams, TQuery, TV2, TR2>,
-    handler3: Handler<TParams, TQuery, TV3, TR3>,
-    handler4: Handler<TParams, TQuery, TV4, TR4>
+    handler1: Handler<THttpMethod, TParams, TQuery, TV1, TR1>,
+    handler2: Handler<THttpMethod, TParams, TQuery, TV2, TR2>,
+    handler3: Handler<THttpMethod, TParams, TQuery, TV3, TR3>,
+    handler4: Handler<THttpMethod, TParams, TQuery, TV4, TR4>
   ): HttpMethodMapping<
     THttpMethod,
     TParams,
@@ -163,11 +164,11 @@ export interface MethodRouteDefinition<
     TR4 extends RouteResponse = RouteResponse,
     TR5 extends RequiredRouteResponse = RequiredRouteResponse,
   >(
-    handler1: Handler<TParams, TQuery, TV1, TR1>,
-    handler2: Handler<TParams, TQuery, TV2, TR2>,
-    handler3: Handler<TParams, TQuery, TV3, TR3>,
-    handler4: Handler<TParams, TQuery, TV4, TR4>,
-    handler5: Handler<TParams, TQuery, TV5, TR5>
+    handler1: Handler<THttpMethod, TParams, TQuery, TV1, TR1>,
+    handler2: Handler<THttpMethod, TParams, TQuery, TV2, TR2>,
+    handler3: Handler<THttpMethod, TParams, TQuery, TV3, TR3>,
+    handler4: Handler<THttpMethod, TParams, TQuery, TV4, TR4>,
+    handler5: Handler<THttpMethod, TParams, TQuery, TV5, TR5>
   ): HttpMethodMapping<
     THttpMethod,
     TParams,
@@ -190,12 +191,12 @@ export interface MethodRouteDefinition<
     TR5 extends RouteResponse = RouteResponse,
     TR6 extends RequiredRouteResponse = RequiredRouteResponse,
   >(
-    handler1: Handler<TParams, TQuery, TV1, TR1>,
-    handler2: Handler<TParams, TQuery, TV2, TR2>,
-    handler3: Handler<TParams, TQuery, TV3, TR3>,
-    handler4: Handler<TParams, TQuery, TV4, TR4>,
-    handler5: Handler<TParams, TQuery, TV5, TR5>,
-    handler6: Handler<TParams, TQuery, TV6, TR6>
+    handler1: Handler<THttpMethod, TParams, TQuery, TV1, TR1>,
+    handler2: Handler<THttpMethod, TParams, TQuery, TV2, TR2>,
+    handler3: Handler<THttpMethod, TParams, TQuery, TV3, TR3>,
+    handler4: Handler<THttpMethod, TParams, TQuery, TV4, TR4>,
+    handler5: Handler<THttpMethod, TParams, TQuery, TV5, TR5>,
+    handler6: Handler<THttpMethod, TParams, TQuery, TV6, TR6>
   ): HttpMethodMapping<
     THttpMethod,
     TParams,

--- a/src/rpc/server/types.ts
+++ b/src/rpc/server/types.ts
@@ -6,6 +6,7 @@ import type {
   RedirectionHttpStatusCode,
   SuccessfulHttpStatusCode,
 } from "../lib/http-status-code-types";
+import type { HttpMethod } from "../lib/types";
 import type { NextResponse, NextRequest } from "next/server";
 
 /**
@@ -205,12 +206,12 @@ export type ValidatedData = {
   [__validatedBrand]: true;
 };
 
-export type ValidationTarget =
-  | "params"
-  | "query"
-  | "json"
-  | "headers"
-  | "cookies";
+type ValidationTargetKey = "params" | "query" | "json" | "headers" | "cookies";
+
+export type ValidationTarget<THttpMethod extends HttpMethod = HttpMethod> =
+  THttpMethod extends "GET" | "HEAD"
+    ? Exclude<ValidationTargetKey, "json">
+    : ValidationTargetKey;
 
 type ValidationFor<
   TDirection extends keyof ValidationSchema,


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

- Added `HttpMethod` typing to `handler`, `validator`, and `validation targets` to improve type safety.
- Updated `createHandler`, `validator`, and `zValidator` to accept `HttpMethod` as a generic parameter.
- Adjusted related type definitions in `route-types.ts` and `types.ts`.
- Updated test cases to cover `HttpMethod` specific behavior.

## 🔎 Motivation and Background

- Previously, `handler` and `validator` logic did not differentiate by HTTP method.
- This could cause type mismatches, especially for methods like `GET` or `HEAD` where `json` validation is invalid.
- By introducing `HttpMethod` typing, stricter and more accurate validation flows are enforced at compile-time.

## ✅ Changes

- [x] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- None

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed