### PR TITLE
docs: add explanation comment for _THttpMethod in Handler type

### DIFF
--- a/src/rpc/server/route-types.ts
+++ b/src/rpc/server/route-types.ts
@@ -32,6 +32,7 @@ export interface ValidationSchema {
 }
 
 export type Handler<
+  // _THttpMethod is used to propagate the current HttpMethod type to the Handler.
   _THttpMethod extends HttpMethod,
   TParams = Params,
   TQuery = Query,


### PR DESCRIPTION
## 📝 Overview

- Added an explanatory comment for the `_THttpMethod` type parameter in the `Handler` type definition.

## 🧐 Motivation and Background

- The `_THttpMethod` type parameter exists to propagate the `HttpMethod` type information into the `Handler` type.
- Although it is not directly used within the `Handler`, it serves an important role for type inference and future extensibility.
- Adding a comment improves code readability and helps future developers understand its purpose immediately.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [x] Documentation updated

## 💡 Notes / Screenshots

- None

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed