### PR TITLE
docs: update description to remove reference to `honolike` in type-safety section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,7 @@ export default async function Page() {
 
 ---
 
-## ✅ さらに型安全にしたい場合 `honolike` + `createRouteHandler` による Next.js の型安全強化
-
-さらに `honolike` をベースとした `createRouteHandler()` を組み合わせることで、
+## ✅ さらに型安全にしたい場合 `createRouteHandler` による Next.js の型安全強化
 
 ### 📌 主なメリット
 


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

- Removed reference to `honolike` in the "further type safety" section of the README.
- Updated the section title and description to focus solely on `createRouteHandler`.

## 💮 Motivation and Background

- `honolike` is no longer a necessary mention for achieving additional type safety with `createRouteHandler`.
- Simplifies the explanation and avoids confusion.

## ✅ Changes

- [ ] Feature added
- [ ] Bug fixed
- [ ] Refactored
- [x] Documentation updated

## 💡 Notes / Screenshots

- No functional changes, documentation only.

## 🔄 Testing

- [ ] `bun run lint` passed
- [ ] `bun run test` passed
- [x] Manual verification completed (README renderin