### PR TITLE
chore: change Dependabot bun update schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "bun"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     versioning-strategy: increase
     groups:
       bun:


### PR DESCRIPTION
## 📝 Overview

- Changed Dependabot update schedule for `bun` ecosystem from `daily` to `weekly`.

## 💮 Motivation and Background

- To reduce the frequency of pull requests created by Dependabot.
- Daily updates were too frequent for the project's needs, and weekly updates provide a better balance between staying updated and maintaining manageable PR traffic.

## ✅ Changes

- [x] Updated `.github/dependabot.yml`:
  - Changed `schedule.interval` for `bun` from `"daily"` to `"weekly"`.

## 💡 Notes / Screenshots

- No functional changes to the application.
- Only Dependabot's PR generation frequency is affected.

## 🔄 Testing

- [x] Verified `.github/dependabot.yml` syntax is correct.
- [x] Confirmed that the configuration will apply on the next Dependabot run.