### PR TITLE
refactor: simplify ParamFunction variadic tuple usage for clarity

### DIFF
--- a/src/rpc/client/types.ts
+++ b/src/rpc/client/types.ts
@@ -172,7 +172,7 @@ type PathProxyAsFunction<T> = {
 } & (T extends IsHttpMethod ? InferHttpMethods<T> : unknown);
 
 type ParamFunction<T, TParamArgs extends unknown[]> = (
-  ...args: [...TParamArgs]
+  ...args: TParamArgs
 ) => DynamicPathProxyAsFunction<T>;
 
 type NonEmptyArray<T> = [T, ...T[]];


### PR DESCRIPTION
## 📝 Overview

- Refactored the `ParamFunction` type definition in `src/rpc/client/types.ts` to simplify the usage of variadic tuples.

## 🧐 Motivation and Background

- The use of `[...TParamArgs]` in the spread operator was redundant and unnecessary.
- Simplifying this enhances readability and maintains the same type behavior.

## ✅ Changes

- [x] Refactored `ParamFunction` to use `...args: TParamArgs` instead of `...args: [...TParamArgs]`

## 💡 Notes / Screenshots

- This change has no impact on runtime behavior or type inference.

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed
