### PR TITLE
feat: support headersInit property separately from headers in client options

### DIFF
--- a/src/rpc/client/http-method.test.ts
+++ b/src/rpc/client/http-method.test.ts
@@ -309,6 +309,88 @@ describe("httpMethod (integration test without excessive mocks)", () => {
     await expect(requestFn()).rejects.toThrow(errorMessage);
   });
 
+  it("should correctly merge default Headers instance with client headers object", async () => {
+    const key = "$get";
+    const paths = ["http://example.com", "api", "headersTest"];
+    const params = {};
+    const dynamicKeys: string[] = [];
+
+    let calledInit: CapturedInit | undefined = {};
+    global.fetch = ((_input: RequestInfo | URL, _init?: RequestInit) => {
+      calledInit = _init as CapturedInit | undefined;
+
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as typeof fetch;
+
+    const defaultHeaders = new Headers();
+    defaultHeaders.append("X-Default", "defaultValue");
+    const clientHeaders = { "x-custom": "customValue" };
+
+    const defaultOptions = {
+      init: { headersInit: defaultHeaders },
+    };
+
+    const requestFn = httpMethod(
+      key,
+      paths,
+      params,
+      dynamicKeys,
+      defaultOptions
+    );
+
+    const clientOptions = {
+      init: { headers: clientHeaders },
+    };
+
+    await requestFn(undefined, clientOptions);
+
+    expect(calledInit?.headers).toEqual({
+      "x-default": "defaultValue",
+      "x-custom": "customValue",
+    });
+  });
+
+  it("should correctly merge default headers object with client Headers instance", async () => {
+    const key = "$get";
+    const paths = ["http://example.com", "api", "headersTest"];
+    const params = {};
+    const dynamicKeys: string[] = [];
+
+    let calledInit: CapturedInit | undefined = {};
+    global.fetch = ((_input: RequestInfo | URL, _init?: RequestInit) => {
+      calledInit = _init as CapturedInit | undefined;
+
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as typeof fetch;
+
+    const clientHeaders = new Headers();
+    clientHeaders.append("X-Default", "defaultValue");
+    const defaultHeaders = { "x-custom": "customValue" };
+
+    const defaultOptions = {
+      init: { headersInit: clientHeaders },
+    };
+
+    const requestFn = httpMethod(
+      key,
+      paths,
+      params,
+      dynamicKeys,
+      defaultOptions
+    );
+
+    const clientOptions = {
+      init: { headers: defaultHeaders },
+    };
+
+    await requestFn(undefined, clientOptions);
+
+    expect(calledInit?.headers).toEqual({
+      "x-default": "defaultValue",
+      "x-custom": "customValue",
+    });
+  });
+
   it("should correctly merge Headers passed as a Headers instance and an array", async () => {
     const key = "$get";
     const paths = ["http://example.com", "api", "headersTest"];
@@ -329,7 +411,7 @@ describe("httpMethod (integration test without excessive mocks)", () => {
     const clientHeaders: [string, string][] = [["X-Custom", "customValue"]];
 
     const defaultOptions = {
-      init: { headers: defaultHeaders },
+      init: { headersInit: defaultHeaders },
     };
 
     const requestFn = httpMethod(
@@ -341,7 +423,7 @@ describe("httpMethod (integration test without excessive mocks)", () => {
     );
 
     const clientOptions = {
-      init: { headers: clientHeaders },
+      init: { headersInit: clientHeaders },
     };
 
     await requestFn(undefined, clientOptions);
@@ -372,7 +454,7 @@ describe("httpMethod (integration test without excessive mocks)", () => {
     clientHeaders.append("X-Test", "client");
 
     const defaultOptions = {
-      init: { headers: defaultHeaders },
+      init: { headersInit: defaultHeaders },
     };
 
     const requestFn = httpMethod(
@@ -384,7 +466,7 @@ describe("httpMethod (integration test without excessive mocks)", () => {
     );
 
     const clientOptions = {
-      init: { headers: clientHeaders },
+      init: { headersInit: clientHeaders },
     };
 
     await requestFn(undefined, clientOptions);

--- a/src/rpc/client/http-method.ts
+++ b/src/rpc/client/http-method.ts
@@ -72,9 +72,11 @@ export const httpMethod = (
     const defaultInit = defaultOptions.init ?? {};
     const innerInit = options?.init ?? {};
 
-    const defaultHeaders = normalizeHeaders(defaultInit.headers);
+    const defaultHeaders = normalizeHeaders(
+      defaultInit.headers ?? defaultInit.headersInit
+    );
     const innerHeaders = normalizeHeaders(
-      methodParamHeaders ?? innerInit.headers
+      methodParamHeaders ?? innerInit.headers ?? innerInit.headersInit
     );
     const mergedHeaders: Record<string, string> = {
       ...defaultHeaders,
@@ -91,13 +93,22 @@ export const httpMethod = (
         .join("; ");
     }
 
-    const { headers: _defaultHeaders, ...defaultInitWithoutHeaders } =
-      defaultInit;
-    const { headers: _innerHeaders, ...innerInitWithoutHeaders } = innerInit;
+    const {
+      headers: _defHeaders,
+      headersInit: _defHeadersInit,
+      ...defaultInitWithoutHeaders
+    } = defaultInit;
+    const {
+      headers: _innHeaders,
+      headersInit: _innHeadersInit,
+      ...innerInitWithoutHeaders
+    } = innerInit;
+
     const mergedInit: TypedRequestInit = deepMerge(
       defaultInitWithoutHeaders,
       innerInitWithoutHeaders
     );
+
     mergedInit.method = method;
 
     if (Object.keys(mergedHeaders).length > 0) {

--- a/src/rpc/client/rpc-validater.test.ts
+++ b/src/rpc/client/rpc-validater.test.ts
@@ -378,7 +378,7 @@ describe("createHandler type definitions", () => {
           };
         };
       },
-      option?: ClientOptions<never, "headers">,
+      option?: ClientOptions<never, "headers" | "headersInit">,
     ];
 
     expectTypeOf<
@@ -495,7 +495,10 @@ describe("createHandler type definitions", () => {
           };
         };
       },
-      option?: ClientOptions<"Cookie" | "Content-Type", "headers" | "body">,
+      option?: ClientOptions<
+        "Cookie" | "Content-Type",
+        "headers" | "headersInit" | "body"
+      >,
     ];
 
     expectTypeOf<

--- a/src/rpc/client/types.ts
+++ b/src/rpc/client/types.ts
@@ -15,23 +15,35 @@ import type {
 import type { TypedNextResponse, ValidationInputFor } from "../server/types";
 import type { NextResponse } from "next/server";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DistributeOmit<T, K extends keyof any> = T extends any
+  ? Omit<T, K>
+  : never;
+
 /**
  * Extension of the standard `RequestInit` interface with strongly typed headers.
  */
-export interface TypedRequestInit<
-  TWithoutHeaders extends "Content-Type" | "Cookie" = never,
-> extends RequestInit {
-  headers?:
-    | (Omit<HttpRequestHeaders, TWithoutHeaders> & Record<string, string>)
-    | HeadersInit;
-}
+export type TypedRequestInit<
+  TWithoutHeaders extends keyof HttpRequestHeaders = never,
+> = Omit<RequestInit, "headers"> &
+  (
+    | {
+        headers?: Omit<HttpRequestHeaders, TWithoutHeaders> &
+          Record<string, string>;
+        headersInit?: never;
+      }
+    | {
+        headers?: never;
+        headersInit?: HeadersInit;
+      }
+  );
 
 export type ClientOptions<
   TWithoutHeaders extends "Content-Type" | "Cookie" = never,
-  TWithoutInit extends "body" | "headers" = never,
+  TWithoutInit extends "body" | "headers" | "headersInit" = never,
 > = {
   fetch?: typeof fetch;
-  init?: Omit<TypedRequestInit<TWithoutHeaders>, TWithoutInit>;
+  init?: DistributeOmit<TypedRequestInit<TWithoutHeaders>, TWithoutInit>;
 };
 
 declare const __proxy: unique symbol;
@@ -123,7 +135,7 @@ type HttpMethodsArgs<
     | (IsNever<TJson> extends true ? never : "Content-Type")
     | (IsNever<TCookies> extends true ? never : "Cookie"),
     | (IsNever<TJson> extends true ? never : "body")
-    | (IsNever<THeaders> extends true ? never : "headers")
+    | (IsNever<THeaders> extends true ? never : "headers" | "headersInit")
   >,
 ];
 


### PR DESCRIPTION
## 📝 Overview

- Separated `headers` and `headersInit` in `TypedRequestInit`.
- Added support for `headersInit` in `ClientOptions`.
- Updated `httpMethod` to properly merge `headers` and `headersInit`.
- Added tests to verify merging behavior for various combinations of `headers` and `headersInit`.

## 💪 Motivation and Background

- Previously, `headers` accepted both strongly typed headers and `HeadersInit`, causing confusing type inference and less clear client usage.
- By separating `headers` and `headersInit`, it is now clearer and more type-safe to pass either structured headers or standard `Headers`, `HeadersInit` (e.g., `Headers`, `[string, string][]`, or `Record<string, string>`).
- This enables better DX (developer experience) and makes header merging behavior more predictable and reliable.

## ✅ Changes

- [x] Feature added
- [ ] Bug fixed
- [x] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- `headers` is now exclusively for strongly typed structured headers.
- `headersInit` is used for raw `HeadersInit` types.
- Merging prioritizes client headers over default headers.
- The default headers and client headers are normalized and merged case-insensitively.

## 🐄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed