### PR TITLE
feat: support passing status code directly to response helpers in route context

### DIFF
--- a/src/rpc/server/route-context.ts
+++ b/src/rpc/server/route-context.ts
@@ -23,9 +23,13 @@ const isHttpStatusCode = (value: unknown): value is HttpStatusCode => {
 };
 
 const resolvedHeaders = (
-  init?: TypedResponseInit<HttpStatusCode, ContentType>
+  init?: HttpStatusCode | TypedResponseInit<HttpStatusCode, ContentType>
 ) => {
   if (!init) return init;
+
+  if (isHttpStatusCode(init)) {
+    return { status: init };
+  }
 
   const headers = init.headers ?? normalizeHeaders(init.headersInit);
 
@@ -71,7 +75,7 @@ export const createRouteContext = <
       TStatus extends HttpStatusCode = 200,
     >(
       data: TData,
-      init?: TypedResponseInit<TStatus, TContentType>
+      init?: TStatus | TypedResponseInit<TStatus, TContentType>
     ) =>
       new NextResponse<TData>(data, resolvedHeaders(init)) as TypedNextResponse<
         TData,
@@ -81,7 +85,7 @@ export const createRouteContext = <
 
     json: <TData, TStatus extends HttpStatusCode = 200>(
       data: TData,
-      init?: TypedResponseInit<TStatus, "application/json">
+      init?: TStatus | TypedResponseInit<TStatus, "application/json">
     ) =>
       NextResponse.json<TData>(
         data,
@@ -90,7 +94,7 @@ export const createRouteContext = <
 
     text: <TData extends string, TStatus extends HttpStatusCode = 200>(
       data: TData,
-      init?: TypedResponseInit<TStatus, "text/plain">
+      init?: TStatus | TypedResponseInit<TStatus, "text/plain">
     ) => {
       const resolvedInit = resolvedHeaders(init);
 

--- a/src/rpc/server/types.ts
+++ b/src/rpc/server/types.ts
@@ -166,7 +166,7 @@ export interface RouteContext<
     TStatus extends HttpStatusCode = 200,
   >(
     data: TData,
-    init?: TypedResponseInit<TStatus, TContentType>
+    init?: TStatus | TypedResponseInit<TStatus, TContentType>
   ) => TypedNextResponse<TData, TStatus, TContentType>;
 
   /**
@@ -178,7 +178,7 @@ export interface RouteContext<
    */
   json: <TData, TStatus extends HttpStatusCode = 200>(
     data: TData,
-    init?: TypedResponseInit<TStatus, "application/json">
+    init?: TStatus | TypedResponseInit<TStatus, "application/json">
   ) => TypedNextResponse<TData, TStatus, "application/json">;
 
   /**
@@ -191,7 +191,7 @@ export interface RouteContext<
    */
   text: <TData extends string, TStatus extends HttpStatusCode = 200>(
     data: TData,
-    init?: TypedResponseInit<TStatus, "text/plain">
+    init?: TStatus | TypedResponseInit<TStatus, "text/plain">
   ) => TypedNextResponse<TData, TStatus, "text/plain">;
 
   /**


### PR DESCRIPTION
## 📝 Overview

- Extended `RouteContext` response helpers (`body`, `json`, `text`, `redirect`) to allow passing a status code directly as the second argument.
- Adjusted implementation to normalize and resolve the init options correctly whether a status code or a full `TypedResponseInit` object is provided.
- Updated `resolvedHeaders` function to support both input types.
- Added comprehensive tests for all response helpers covering the new usage style.

## 🧐 Motivation and Background

- Previously, response helpers required a full `TypedResponseInit` object even when only a status code was needed.
- This led to unnecessarily verbose code and reduced developer ergonomics.
- Supporting direct status codes simplifies common usage patterns and improves DX.

## ✅ Changes

- [x] Feature added: Allow status code as `init` in `context.body`, `context.json`, `context.text`, and `context.redirect`
- [x] Type definition updates in `RouteContext`
- [x] Implementation updates in `route-context.ts`
- [x] Unit tests added in `route-context.test.ts`

## 💡 Notes / Screenshots

- The new API maintains backward compatibility and improves type inference with `as const` usage on the status code.

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed