### PR TITLE
chore: use Bun instead of Node to get version from package.json in release workflow

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Get version from package.json
         id: get_version
-        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(bun -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## 📝 Overview

- Replaced Node.js with Bun in GitHub Actions release workflow to retrieve the version from package.json

## 😮 Motivation and Background

- Aligns with the project's move to Bun as the default runtime
- Reduces dependency on Node.js tooling in CI

## ✅ Changes

- [x] Tool configuration updated to use `bun -p` instead of `node -p` in the release-on-merge workflow

## 💡 Notes / Screenshots

- None

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed