### PR TITLE
chore: simplify externals definition and remove unnecessary spread in build script

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -14,15 +14,15 @@ const baseOptions: BuildOptions = {
 
 const entriesForCli = await glob(["src/rpc/cli/index.ts"]);
 const externals = [
-  ...Object.keys(pkg.dependencies || {}),
-  ...Object.keys(pkg.peerDependencies || {}),
+  ...Object.keys(pkg.dependencies),
+  ...Object.keys(pkg.peerDependencies),
 ];
 await build({
   ...baseOptions,
   entryPoints: entriesForCli,
   platform: "node",
   bundle: true,
-  external: [...externals],
+  external: externals,
   banner: {
     js: "#!/usr/bin/env node",
   },


### PR DESCRIPTION
## 📝 Overview

- Removed unnecessary spread syntax when assigning `externals` array in `build.ts`
- Directly passed `dependencies` and `peerDependencies` keys without fallback to empty object

## 🧐 Motivation and Background

- The fallback to `{}` in `Object.keys(pkg.dependencies || {})` is redundant because `pkg.dependencies` and `pkg.peerDependencies` are known to exist in the context
- The spread on `externals` during `build()` call was unnecessary and reduced readability

## ✅ Changes

- [x] Code simplified for `externals` definition in `build.ts`
- [ ] Feature added
- [ ] Bug fixed
- [x] Refactored
- [ ] Documentation updated

## 💡 Notes / Screenshots

- None

## 🔄 Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed