### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # rpc4next
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/watanabe-1/rpc4next)
+
 Lightweight, type-safe RPC system for Next.js App Router projects.
 
 Inspired by Hono RPC and Pathpida, **rpc4next** automatically generates a type-safe client for your existing `route.ts` **and** `page.tsx` files, enabling seamless server-client communication with full type inference.


### PR DESCRIPTION
## 📝 Overview

* Added a DeepWiki badge to the top of the `README.md` file for the `rpc4next` project.

## 🧐 Motivation and Background

* To enhance project visibility and provide a direct link to the DeepWiki page, making it easier for users to explore structured documentation or insights.

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [x] Documentation updated

## 💡 Notes / Screenshots

* Markdown badge added:

  ```md
  [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/watanabe-1/rpc4next)
  ```

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [x] Manual verification completed

  * Verified that the badge appears correctly in the rendered README.