### PR TITLE
chore: update test coverage workflow to include actions read permission and coverage artifact details

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      actions: read
       pull-requests: write
 
     steps:
@@ -19,6 +20,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
+          name: coverage
+          path: coverage
       - name: "Report Coverage"
         uses: davelosert/vitest-coverage-report-action@v2
         with:


### PR DESCRIPTION
## 📝 Overview

* Added `actions: read` permission to the workflow.
* Updated `vitest-coverage-report-action` step to include `name` and `path` for the coverage artifact.

## 🧐 Motivation and Background

* Required `actions: read` permission for accessing workflow run data.
* Explicit artifact naming and path improves clarity and retrieval of coverage reports.

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [ ] Documentation updated
* [x] Build-related or tool configuration changes

## 💡 Notes / Screenshots

* Ensures consistent artifact handling across runs.

## 🔄 Testing

* [x] `bun run lint` passed
* [x] `bun run test` passed
* [x] Manual verification completed
