### PR TITLE
feat(httpMethod): body inference & smart content-type, cookie merge; strip body on GET/HEAD; better errors + tests

### DIFF
--- a/src/rpc/client/http-method.ts
+++ b/src/rpc/client/http-method.ts
@@ -11,6 +11,40 @@ import type {
 } from "./types";
 import type { ContentType } from "../lib/content-type-types";
 
+/** Local, non-breaking extension for future body shapes */
+type ExtendedBodyOptions = BodyOptions & {
+  text?: string;
+  formData?: FormData;
+  urlencoded?: URLSearchParams;
+  raw?: BodyInit;
+};
+
+/** Remove headers/headersInit from a RequestInit-like object (typed, no any). */
+function stripHeaders(
+  init?: TypedRequestInit
+): Omit<TypedRequestInit, "headers" | "headersInit"> {
+  if (!init) return {};
+  const { headers: _h, headersInit: _hi, ...rest } = init;
+
+  return rest;
+}
+
+/** Whether the user already set Content-Type (case-insensitive). */
+function hasUserContentType(h: Record<string, string>): boolean {
+  // normalizeHeaders lowercases keys, but be defensive:
+  if ("content-type" in h) return true;
+
+  return Object.keys(h).some((k) => k.toLowerCase() === "content-type");
+}
+
+/**
+ * Build a typed HTTP method invoker.
+ * - Header precedence: default < options.init < methodParam.requestHeaders
+ * - Do NOT override user-specified `content-type`.
+ * - Merge cookies instead of clobbering.
+ * - Never attach a body for GET/HEAD.
+ * - Provide basic body-shape inference (json/text/formData/urlencoded) while keeping current types compatible.
+ */
 export const httpMethod = (
   key: string,
   paths: string[],
@@ -21,83 +55,107 @@ export const httpMethod = (
   return async (
     methodParam?: {
       url?: UrlOptions;
-      body?: BodyOptions;
+      body?: ExtendedBodyOptions;
       requestHeaders?: HeadersOptions;
     },
     options?: ClientOptions
   ) => {
-    let methodParamBody: BodyInit | undefined = undefined;
-    let methodParamContentType: ContentType | undefined = undefined;
-
-    if (methodParam?.body?.json) {
-      methodParamContentType = "application/json";
-      methodParamBody = JSON.stringify(methodParam.body.json);
-    }
-
-    const methodParamHeaders = methodParam?.requestHeaders?.headers as
-      | Record<string, string>
-      | undefined;
-    const methodParamCookies = methodParam?.requestHeaders?.cookies as
-      | Record<string, string>
-      | undefined;
-
-    const urlObj = createUrl([...paths], params, dynamicKeys)(methodParam?.url);
+    // Resolve method (e.g. "$get" -> "GET")
     const method = key.replace(/^\$/, "").toUpperCase();
 
+    // Build URL (path + query from url options)
+    const urlObj = createUrl([...paths], params, dynamicKeys)(methodParam?.url);
+
+    // Select fetch implementation
     const customFetch = options?.fetch ?? defaultOptions.fetch ?? fetch;
 
-    const defaultInit = defaultOptions.init ?? {};
-    const innerInit = options?.init ?? {};
+    // --- Merge headers (default < options.init < methodParam.requestHeaders)
+    const defaultInit = defaultOptions.init;
+    const innerInit = options?.init;
 
     const defaultHeaders = normalizeHeaders(
-      defaultInit.headers ?? defaultInit.headersInit
+      defaultInit?.headers ?? defaultInit?.headersInit
     );
     const innerHeaders = normalizeHeaders(
-      methodParamHeaders ?? innerInit.headers ?? innerInit.headersInit
+      innerInit?.headers ?? innerInit?.headersInit
     );
+    const methodParamHeaders = normalizeHeaders(
+      methodParam?.requestHeaders?.headers as Record<string, string> | undefined
+    );
+
+    // Start from low precedence and overlay higher precedence
     const mergedHeaders: Record<string, string> = {
       ...defaultHeaders,
       ...innerHeaders,
+      ...methodParamHeaders,
     };
 
-    if (methodParamContentType) {
-      mergedHeaders["content-type"] = methodParamContentType;
-    }
-
-    if (methodParamCookies) {
-      mergedHeaders["cookie"] = Object.entries(methodParamCookies)
-        .map(([key, value]) => `${key}=${value}`)
+    // ---- Cookies: merge (existing cookie header + methodParam cookies map)
+    const existingCookie = mergedHeaders["cookie"];
+    const methodParamCookies = methodParam?.requestHeaders?.cookies;
+    if (methodParamCookies && Object.keys(methodParamCookies).length > 0) {
+      const cookieFromMap = Object.entries(methodParamCookies)
+        .map(([k, v]) => `${k}=${v}`)
         .join("; ");
+      mergedHeaders["cookie"] = existingCookie
+        ? `${existingCookie}; ${cookieFromMap}`
+        : cookieFromMap;
     }
 
-    const {
-      headers: _defHeaders,
-      headersInit: _defHeadersInit,
-      ...defaultInitWithoutHeaders
-    } = defaultInit;
-    const {
-      headers: _innHeaders,
-      headersInit: _innHeadersInit,
-      ...innerInitWithoutHeaders
-    } = innerInit;
+    // --- Body & content-type inference
+    let bodyInit: BodyInit | undefined;
+    let inferredContentType: ContentType | undefined;
 
+    const b = methodParam?.body;
+
+    if (b?.json !== undefined) {
+      bodyInit = JSON.stringify(b.json);
+      inferredContentType = "application/json";
+    } else if (typeof b?.text === "string") {
+      bodyInit = b.text;
+      inferredContentType = "text/plain; charset=utf-8";
+    } else if (b?.formData instanceof FormData) {
+      bodyInit = b.formData; // boundary is auto-generated; do not set Content-Type explicitly
+      inferredContentType = undefined;
+    } else if (b?.urlencoded instanceof URLSearchParams) {
+      bodyInit = b.urlencoded;
+      inferredContentType = "application/x-www-form-urlencoded; charset=UTF-8";
+    } else if (b?.raw !== undefined) {
+      bodyInit = b.raw;
+      inferredContentType = undefined;
+    }
+
+    // Do not attach a body to GET or HEAD requests
+    if (method === "GET" || method === "HEAD") {
+      bodyInit = undefined;
+    }
+
+    // Only set Content-Type when the user hasn't specified one
+    if (!hasUserContentType(mergedHeaders) && bodyInit && inferredContentType) {
+      mergedHeaders["content-type"] = inferredContentType;
+    }
+
+    // --- Build final init
     const mergedInit: TypedRequestInit = deepMerge(
-      defaultInitWithoutHeaders,
-      innerInitWithoutHeaders
+      stripHeaders(defaultInit),
+      stripHeaders(innerInit)
     );
-
     mergedInit.method = method;
 
     if (Object.keys(mergedHeaders).length > 0) {
       mergedInit.headers = mergedHeaders;
     }
-
-    if (methodParamBody) {
-      mergedInit.body = methodParamBody;
+    if (bodyInit !== undefined) {
+      mergedInit.body = bodyInit;
     }
 
-    const response = await customFetch(urlObj.path, mergedInit);
-
-    return response;
+    // ---- Fetch with helpful error surface
+    try {
+      return await customFetch(urlObj.path, mergedInit);
+    } catch (err) {
+      // Surface method and URL for easier debugging
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`[httpMethod] ${method} ${urlObj.path} failed: ${msg}`);
+    }
   };
 };


### PR DESCRIPTION
# feat(httpMethod): body inference & smart content-type, cookie merge; strip body on GET/HEAD; better errors + tests

**Branch:** `feat/http-method-body-inference-cookie-merge`

---

## 📝 Overview

* Added richer body support via `ExtendedBodyOptions` (json / text / formData / urlencoded / raw)
* Infer `Content-Type` when not provided by user (JSON / text/plain; charset=utf-8 / application/x-www-form-urlencoded; charset=UTF-8)
* Never set `Content-Type` for `FormData` or `raw` bodies
* Do **not** override user-provided `Content-Type`
* Remove body for `GET`/`HEAD` methods
* Merge cookies (existing `Cookie` header + `requestHeaders.cookies` map)
* Preserve header precedence: **default < options.init < methodParam.requestHeaders**
* Safer init building via `stripHeaders` and `deepMerge`
* More helpful error messages: include method & URL, wrap non-Error rejections
* Updated/added tests covering the above behaviors

---

## 🧐 Motivation and Background

* Make `httpMethod` easier to use with common body types without verbose configuration
* Prevent accidental header clobbering and respect user intent for `Content-Type`
* Align with HTTP semantics (no body on `GET`/`HEAD`)
* Improve debuggability with clearer error surfaces

---

## ✅ Changes

* [x] Feature added
* [ ] Bug fixed
* [x] Refactored
* [ ] Documentation updated

**Key code changes**

* Introduced `ExtendedBodyOptions` type (json/text/formData/urlencoded/raw)
* Added `stripHeaders`, `hasUserContentType` utilities
* Content-Type inference logic with case-insensitive detection
* Cookie merge logic (append to existing `Cookie` header)
* Enforced body removal for `GET`/`HEAD`
* Error handling wraps non-Error rejections: `[httpMethod] <METHOD> <URL> failed: <msg>`
* Tests updated/added: header merges (objects/arrays/Headers), content-type inference, cookie merge, GET/HEAD body stripping, FormData no explicit content-type, urlencoded handling, raw body, non-Error rejection wrap, precedence of `options.fetch`

---

## 💡 Notes / Screenshots

* Backward compatibility: existing behavior is preserved unless code relied on previous (non-compliant) body-on-GET/HEAD or on automatic `Content-Type` override.
* Potential subtle change: `Content-Type` is **not** auto-set when user already provided one; `FormData`/`raw` do not get forced `Content-Type`.

---

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed

**Added/updated tests (highlights)**

* `$post` with `body.json` infers `application/json` when none provided
* Does not override user `Content-Type`
* `FormData` body: no explicit `Content-Type`
* `URLSearchParams` body: sets `application/x-www-form-urlencoded; charset=UTF-8`
* Text body: sets `text/plain; charset=utf-8`
* Raw body: does not set `Content-Type`
* `GET`/`HEAD`: body is always removed
* Cookie merge (`Cookie` + `requestHeaders.cookies`)
* Header precedence and mixed `HeadersInit` forms
* Wrap non-Error rejections with helpful message
