### PR TITLE
chore(deps-dev): add diff2prompt and npm script with excludes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ next-env.d.ts
 
 # git
 generated-prompt.txt
-generatePromptFromGitDiff.mjs
 
 # rpc4next
 /dist

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/eslint-plugin": "^1.3.10",
         "@vitest/ui": "^3.2.4",
+        "diff2prompt": "^0.0.5",
         "esbuild": "^0.25.9",
         "eslint": "^9.35.0",
         "eslint-config-prettier": "^10.1.8",
@@ -430,6 +431,8 @@
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
+
+    "diff2prompt": ["diff2prompt@0.0.5", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "diff2prompt": "dist/index.js" } }, "sha512-oBwcsH8i8uaQqqcw8RRvOkWNrOtO7cjFUedBFoJK4NwzNYT1TfHHJSmcjV+LKjARl8Ccj/f5PjuBraPQzGBfpg=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "test:watch": "vitest --watch",
     "lint": "eslint \"**/*.ts\"",
     "lint:fix": "eslint \"**/*.ts\" --fix",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "diff2prompt": "diff2prompt --exclude=bun.lock --excludeFile=.gitignore"
   },
   "dependencies": {
     "chalk": "^5.6.2",
@@ -81,6 +82,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/eslint-plugin": "^1.3.10",
     "@vitest/ui": "^3.2.4",
+    "diff2prompt": "^0.0.5",
     "esbuild": "^0.25.9",
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## 📝 Overview

* Added `diff2prompt` npm script with exclude options (`bun.lock`, `.gitignore`)
* Installed `diff2prompt` as a dev dependency

## 🧐 Motivation and Background

* To simplify generating clean prompts for ChatGPT directly from Git diffs
* Ensures excluded files and `.gitignore` entries are respected automatically

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [ ] Documentation updated
* [x] Tooling/dependency update

## 💡 Notes / Screenshots

* The `diff2prompt` script can be run with `bun run diff2prompt`
* Excludes `bun.lock` and files listed in `.gitignore` by default

## 🔄 Testing

* [x] `bun run lint` passed
* [x] `bun run test` passed
* [x] Manual verification completed
