### PR TITLE
chore(deps-dev): bump diff2prompt to v0.0.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/eslint-plugin": "^1.3.10",
         "@vitest/ui": "^3.2.4",
-        "diff2prompt": "^0.0.5",
+        "diff2prompt": "^0.0.6",
         "esbuild": "^0.25.9",
         "eslint": "^9.35.0",
         "eslint-config-prettier": "^10.1.8",
@@ -432,7 +432,7 @@
 
     "detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
 
-    "diff2prompt": ["diff2prompt@0.0.5", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "diff2prompt": "dist/index.js" } }, "sha512-oBwcsH8i8uaQqqcw8RRvOkWNrOtO7cjFUedBFoJK4NwzNYT1TfHHJSmcjV+LKjARl8Ccj/f5PjuBraPQzGBfpg=="],
+    "diff2prompt": ["diff2prompt@0.0.6", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "diff2prompt": "dist/index.js" } }, "sha512-6Yqx54RAEXZmPE0eBmM6YguTnaivn7V37OmBNYxhHsqmy2v5w6L6nzjcJgdnwmeKhOPJNTfOS46eH9aDjILtJg=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/eslint-plugin": "^1.3.10",
     "@vitest/ui": "^3.2.4",
-    "diff2prompt": "^0.0.5",
+    "diff2prompt": "^0.0.6",
     "esbuild": "^0.25.9",
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Bumped `diff2prompt` dev dependency from v0.0.5 to v0.0.6

## 🧐 Motivation and Background

* Keep development dependencies up to date with the latest improvements and fixes in `diff2prompt`.

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [ ] Documentation updated
* [x] Dependency updated

## 💡 Notes / Screenshots

* No functional code changes, dependency bump only.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
