### PR TITLE
refactor(server): Simplify RouteHandlerResponse undefined exclusion

### DIFF
--- a/packages/rpc4next/src/rpc/server/route-types.ts
+++ b/packages/rpc4next/src/rpc/server/route-types.ts
@@ -61,11 +61,9 @@ export type ErrorHandler<
 
 export type RouteHandlerResponse<
   TRouteResponse extends RouteResponse,
-  // _TValidationSchema is used as a generic to allow referencing the ValidationSchema on the client side.
+  // Kept for type inference from RouteHandler on the client side.
   _TValidationSchema extends ValidationSchema,
-> =
-  // Exclude void | undefined because a response is always returned or an error is thrown internally
-  Promise<Exclude<Awaited<TRouteResponse>, undefined | undefined>>;
+> = Promise<Exclude<Awaited<TRouteResponse>, undefined>>;
 
 export type RouteHandler<
   TParams extends RouteBindings["params"],


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Simplified the `RouteHandlerResponse` type by removing a duplicated `undefined` exclusion and tightening the related inline comment

## 🧐 Motivation and Background

* The previous type used `Exclude<Awaited<TRouteResponse>, undefined | undefined>`, which was redundant
* Updating it to exclude only `undefined` keeps the intent the same while making the type easier to read and maintain
* The inline comment was also adjusted to better reflect that the generic is preserved for client-side type inference

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [x] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* Type-level cleanup only; no runtime behavior changes

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
