### PR TITLE
refactor(client): Narrow helper exports and update URL tests

### DIFF
--- a/packages/rpc4next/src/rpc/client/url.test.ts
+++ b/packages/rpc4next/src/rpc/client/url.test.ts
@@ -1,47 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildUrlSuffix, createUrl, replaceDynamicSegments } from "./url";
-
-describe("buildUrlSuffix", () => {
-  it("returns an empty string when no URL is provided", () => {
-    expect(buildUrlSuffix()).toBe("");
-  });
-
-  it("returns a query string when a query is provided", () => {
-    const url = { query: { foo: "bar", baz: "qux" } };
-    const result = buildUrlSuffix(url);
-    // Since URLSearchParams does not guarantee parameter order,
-    // verify that it starts with '?' and contains each parameter
-    expect(result.startsWith("?")).toBe(true);
-    expect(result).toContain("foo=bar");
-    expect(result).toContain("baz=qux");
-  });
-
-  it("returns a hash string when a hash is provided", () => {
-    const url = { hash: "section1" };
-    expect(buildUrlSuffix(url)).toBe("#section1");
-  });
-
-  it("returns a combined query and hash string when both are provided", () => {
-    const url = { query: { a: "1" }, hash: "section2" };
-    const result = buildUrlSuffix(url);
-    expect(result.startsWith("?")).toBe(true);
-    expect(result).toContain("a=1");
-    expect(result).toContain("#section2");
-  });
-});
-
-describe("replaceDynamicSegments", () => {
-  it("replaces dynamic segments with specified values", () => {
-    const basePath = "/_____optional/___catch/_dynamic";
-    const replacements = {
-      optionalCatchAll: "/opt",
-      catchAll: "/cat",
-      dynamic: "/dyn",
-    };
-    const result = replaceDynamicSegments(basePath, replacements);
-    expect(result).toBe("/opt/cat/dyn");
-  });
-});
+import { createUrl } from "./url";
 
 describe("createUrl", () => {
   it("generates a URL with dynamic parameters and query/hash", () => {
@@ -60,6 +18,35 @@ describe("createUrl", () => {
     expect(result.params).toEqual(expectedParams);
 
     expect(result.pathname).toBe("/user/[id]/profile");
+  });
+
+  it("appends only a hash when provided", () => {
+    const result = createUrl(
+      ["https://example.com", "docs"],
+      {},
+      [],
+    )({
+      hash: "section1",
+    });
+
+    expect(result.relativePath).toBe("/docs#section1");
+    expect(result.path).toBe("https://example.com/docs#section1");
+  });
+
+  it("appends query parameters and hash when both are provided", () => {
+    const result = createUrl(
+      ["https://example.com", "search"],
+      {},
+      [],
+    )({
+      query: { foo: "bar", baz: "qux" },
+      hash: "filters",
+    });
+
+    expect(result.relativePath.startsWith("/search?")).toBe(true);
+    expect(result.relativePath).toContain("foo=bar");
+    expect(result.relativePath).toContain("baz=qux");
+    expect(result.relativePath).toContain("#filters");
   });
 
   it("generates a URL with a catch-all parameter", () => {

--- a/packages/rpc4next/src/rpc/client/url.ts
+++ b/packages/rpc4next/src/rpc/client/url.ts
@@ -31,7 +31,7 @@ import type { PathParamsInput, UrlOptions, UrlResult } from "./types";
  * @param url - Optional URL options containing query parameters and/or a hash fragment.
  * @returns A URL suffix string beginning with `?` and/or `#`, or an empty string if none exist.
  */
-export const buildUrlSuffix = (url?: UrlOptions) => {
+const buildUrlSuffix = (url?: UrlOptions) => {
   if (!url) return "";
   const query = url.query
     ? `?${new URLSearchParams(url.query as Record<string, string>).toString()}`
@@ -84,22 +84,6 @@ export const buildUrlSuffix = (url?: UrlOptions) => {
  *
  * @returns A new path string with all dynamic segment markers replaced.
  */
-export const replaceDynamicSegments = (
-  basePath: string,
-  replacements: {
-    optionalCatchAll: string;
-    catchAll: string;
-    dynamic: string;
-  },
-): string =>
-  basePath
-    // optionalCatchAll
-    .replace(/\/_{5}(\w+)/g, replacements.optionalCatchAll)
-    // catchAll
-    .replace(/\/_{3}(\w+)/g, replacements.catchAll)
-    // dynamic
-    .replace(/\/_(\w+)/g, replacements.dynamic);
-
 const safeDecodeSegment = (value: string) => {
   try {
     return decodeURIComponent(value);
@@ -145,7 +129,7 @@ const getPathnameSegment = (segment: string) => {
  *
  * The returned builder optionally appends a suffix (e.g. query/hash) via
  * `buildUrlSuffix(url)` and also produces a Next.js-style `pathname` by converting
- * dynamic markers using `replaceDynamicSegments`.
+ * underscore-prefixed dynamic markers into their bracket form.
  *
  * In addition, params keys are normalized by removing leading underscores
  * (e.g. `__id` -> `id`) in the returned `params`.
@@ -169,7 +153,7 @@ const getPathnameSegment = (segment: string) => {
  * const result = build({ query: { page: "1" } });
  * // result.path: "https://example.com/users/a%20b?page=1"
  * // result.relativePath: "/users/a%20b?page=1"
- * // result.pathname: "/users/[$1]" (depending on replaceDynamicSegments behavior)
+ * // result.pathname: "/users/[id]"
  * // result.params: { id: "a b" }
  * ```
  */

--- a/packages/rpc4next/src/rpc/server/error.ts
+++ b/packages/rpc4next/src/rpc/server/error.ts
@@ -73,7 +73,7 @@ export interface RpcErrorInit<
   code?: TCode;
 }
 
-export const getDefaultRpcErrorStatus = <TCode extends RpcErrorCode>(
+const getDefaultRpcErrorStatus = <TCode extends RpcErrorCode>(
   code: TCode,
 ): RpcErrorStatus<TCode> => {
   return DEFAULT_RPC_ERROR_STATUS[code] as RpcErrorStatus<TCode>;

--- a/packages/rpc4next/src/rpc/server/procedure-kit.ts
+++ b/packages/rpc4next/src/rpc/server/procedure-kit.ts
@@ -16,9 +16,11 @@ export interface CreateProcedureKitOptions {
   onError: ProcedureOnError;
 }
 
-export const createProcedureKit = <TOnError extends ProcedureOnError>(options: {
-  onError: TOnError;
-}) => {
+export const createProcedureKit = <TOnError extends ProcedureOnError>(
+  options: CreateProcedureKitOptions & {
+    onError: TOnError;
+  },
+) => {
   const presetProcedure = procedure.defaults({
     onError: options.onError,
   });

--- a/packages/rpc4next/src/rpc/server/route-context.ts
+++ b/packages/rpc4next/src/rpc/server/route-context.ts
@@ -24,7 +24,7 @@ type ResponseHelperMetadata = {
   payload?: unknown;
 };
 
-export const responseHelperMetadataSymbol = Symbol.for(
+const responseHelperMetadataSymbol = Symbol.for(
   "rpc4next.response.helper.metadata",
 );
 


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Consolidated URL utility test coverage around `createUrl`
* Added hash-only and query-plus-hash test cases for URL generation
* Reduced the public surface of internal client and server helpers by making non-public utilities module-private
* Tightened `createProcedureKit` options typing by reusing `CreateProcedureKitOptions`

## 🧐 Motivation and Background

* The removed exports (`buildUrlSuffix`, `replaceDynamicSegments`, `getDefaultRpcErrorStatus`, and `responseHelperMetadataSymbol`) are implementation details and do not need to be part of the public module surface
* Keeping URL behavior covered through `createUrl` tests better reflects the public API consumers use
* Reusing the existing options interface in `createProcedureKit` improves type consistency and maintainability

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [x] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* URL generation tests now verify hash-only and query-plus-hash suffix handling through `createUrl`
* Inline documentation was updated to describe pathname conversion without referencing removed helper exports

## 🔄 Testing

* [ ] `bun run lint` passed
* [x] `bun run test` passed
* [ ] Manual verification completed
