### PR TITLE
fix(client): Support array query serialization

### DIFF
--- a/packages/rpc4next/src/rpc/client/http-method.test.ts
+++ b/packages/rpc4next/src/rpc/client/http-method.test.ts
@@ -68,6 +68,31 @@ describe("httpMethod (integration test without excessive mocks)", () => {
     });
   });
 
+  it("serializes array query values as repeated keys and omits undefined values", async () => {
+    const key = "$get";
+    const paths = ["http://example.com", "api", "users"];
+    const params = {};
+    const dynamicKeys: string[] = [];
+
+    let calledUrl: RequestInfo | URL | null = null;
+    const customFetch: typeof fetch = (_input) => {
+      calledUrl = _input;
+
+      return Promise.resolve(new Response(null, { status: 200 }));
+    };
+
+    const requestFn = httpMethod(key, paths, params, dynamicKeys, {
+      fetch: customFetch,
+      init: {},
+    });
+
+    await requestFn({
+      url: { query: { tag: ["a", "b"], q: "term", empty: undefined } },
+    });
+
+    expect(calledUrl).toBe("http://example.com/api/users?tag=a&tag=b&q=term");
+  });
+
   it("uses $post with body.json and sets inferred content-type when none provided", async () => {
     const key = "$post";
     const paths = ["http://example.com", "api", "posts"];

--- a/packages/rpc4next/src/rpc/client/url.test.ts
+++ b/packages/rpc4next/src/rpc/client/url.test.ts
@@ -49,6 +49,32 @@ describe("createUrl", () => {
     expect(result.relativePath).toContain("#filters");
   });
 
+  it("serializes array query values as repeated keys", () => {
+    const result = createUrl(
+      ["https://example.com", "search"],
+      {},
+      [],
+    )({
+      query: { tag: ["a", "b"] },
+    });
+
+    expect(result.relativePath).toBe("/search?tag=a&tag=b");
+    expect(result.path).toBe("https://example.com/search?tag=a&tag=b");
+  });
+
+  it("omits undefined query values", () => {
+    const result = createUrl(
+      ["https://example.com", "search"],
+      {},
+      [],
+    )({
+      query: { tag: undefined, q: "term" },
+    });
+
+    expect(result.relativePath).toBe("/search?q=term");
+    expect(result.path).toBe("https://example.com/search?q=term");
+  });
+
   it("generates a URL with a catch-all parameter", () => {
     const paths = ["https://example.com", "user", "___ids"];
     const params = { ___ids: ["1", "2", "3"] };

--- a/packages/rpc4next/src/rpc/client/url.ts
+++ b/packages/rpc4next/src/rpc/client/url.ts
@@ -33,9 +33,29 @@ import type { PathParamsInput, UrlOptions, UrlResult } from "./types";
  */
 const buildUrlSuffix = (url?: UrlOptions) => {
   if (!url) return "";
-  const query = url.query
-    ? `?${new URLSearchParams(url.query as Record<string, string>).toString()}`
-    : "";
+  const searchParams = new URLSearchParams();
+
+  if (url.query) {
+    for (const [key, value] of Object.entries(
+      url.query as Record<string, string | string[] | undefined>,
+    )) {
+      if (value === undefined) {
+        continue;
+      }
+
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          searchParams.append(key, item);
+        }
+
+        continue;
+      }
+
+      searchParams.append(key, value);
+    }
+  }
+
+  const query = searchParams.size > 0 ? `?${searchParams.toString()}` : "";
   const hash = url.hash ? `#${url.hash}` : "";
 
   return query + hash;


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Updated client URL query serialization to support array values as repeated keys and to omit `undefined` values from the query string
* Added tests covering repeated-key array serialization in both `createUrl` and `httpMethod`
* Added tests confirming `undefined` query values are excluded from generated URLs

## 🧐 Motivation and Background

* The client URL builder previously relied on a direct `URLSearchParams` cast that did not explicitly handle array query values or `undefined` values
* Repeated-key serialization is a common and expected format for array query parameters
* Omitting `undefined` values avoids leaking unintended empty parameters into generated request URLs

## ✅ Changes

* [x] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* This change affects query string generation only
* Array values are serialized as repeated keys, for example `tag=a&tag=b`
* `undefined` query values are skipped entirely

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [x] Manual verification completed
