### PR TITLE
fix(client): Remove body from GET and HEAD requests

### DIFF
--- a/packages/rpc4next/src/rpc/client/http-method.test.ts
+++ b/packages/rpc4next/src/rpc/client/http-method.test.ts
@@ -607,6 +607,40 @@ describe("httpMethod (integration test without excessive mocks)", () => {
     expect(calledInit?.body).toBeUndefined();
   });
 
+  it("removes defaultOptions.init.body for GET requests", async () => {
+    const key = "$get";
+    const paths = ["http://example.com", "api", "nobody"];
+    const params = {};
+    const dynamicKeys: string[] = [];
+
+    let calledInit: CapturedInit | undefined = {};
+    global.fetch = ((_input, _init) => {
+      calledInit = _init as CapturedInit | undefined;
+
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as typeof fetch;
+
+    const defaultOptions = {
+      init: {
+        headers: { Accept: "application/json" },
+        body: "default-body",
+      },
+    };
+    const requestFn = httpMethod(
+      key,
+      paths,
+      params,
+      dynamicKeys,
+      defaultOptions,
+    );
+
+    await requestFn();
+
+    expect(calledInit?.method).toBe("GET");
+    expect(calledInit?.headers).toEqual({ accept: "application/json" });
+    expect(calledInit?.body).toBeUndefined();
+  });
+
   it("does not set content-type for FormData (let the browser set multipart boundary)", async () => {
     const key = "$post";
     const paths = ["http://example.com", "api", "upload"];
@@ -804,6 +838,71 @@ describe("httpMethod (integration test without excessive mocks)", () => {
 
     expect(calledInit?.method).toBe("HEAD");
     expect(calledInit?.body).toBeUndefined();
+  });
+
+  it("removes options.init.body for HEAD requests", async () => {
+    const key = "$head";
+    const paths = ["http://example.com", "api", "head"];
+    const params = {};
+    const dynamicKeys: string[] = [];
+
+    let calledInit: CapturedInit | undefined = {};
+    global.fetch = ((_input, _init) => {
+      calledInit = _init as CapturedInit | undefined;
+
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as typeof fetch;
+
+    const defaultOptions = { init: {} };
+    const requestFn = httpMethod(
+      key,
+      paths,
+      params,
+      dynamicKeys,
+      defaultOptions,
+    );
+
+    await requestFn(undefined, {
+      init: {
+        headers: { Accept: "application/json" },
+        body: "client-body",
+      },
+    });
+
+    expect(calledInit?.method).toBe("HEAD");
+    expect(calledInit?.headers).toEqual({ accept: "application/json" });
+    expect(calledInit?.body).toBeUndefined();
+  });
+
+  it("keeps init.body for POST when no methodParam.body is provided", async () => {
+    const key = "$post";
+    const paths = ["http://example.com", "api", "priority"];
+    const params = {};
+    const dynamicKeys: string[] = [];
+
+    let calledInit: CapturedInit | undefined = {};
+    global.fetch = ((_input, _init) => {
+      calledInit = _init as CapturedInit | undefined;
+
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as typeof fetch;
+
+    const requestFn = httpMethod(key, paths, params, dynamicKeys, {
+      init: {
+        headers: { Accept: "application/json" },
+        body: "default-body",
+      },
+    });
+
+    await requestFn(undefined, {
+      init: {
+        body: "client-body",
+      },
+    });
+
+    expect(calledInit?.method).toBe("POST");
+    expect(calledInit?.headers).toEqual({ accept: "application/json" });
+    expect(calledInit?.body).toBe("client-body");
   });
 
   it("wraps non-Error rejections with helpful message", async () => {

--- a/packages/rpc4next/src/rpc/client/http-method.ts
+++ b/packages/rpc4next/src/rpc/client/http-method.ts
@@ -144,6 +144,10 @@ export const httpMethod = (
     );
     mergedInit.method = method;
 
+    if (method === "GET" || method === "HEAD") {
+      delete mergedInit.body;
+    }
+
     if (Object.keys(mergedHeaders).length > 0) {
       mergedInit.headers = mergedHeaders;
     }


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Remove `init.body` before dispatching `GET` and `HEAD` requests in `httpMethod`
* Add integration-style tests covering body removal for `GET`/`HEAD` and body preservation for `POST`

## 🧐 Motivation and Background

* `GET` and `HEAD` requests should not send a request body
* Default or per-call `init.body` values could previously leak into bodyless methods, so the client should strip them consistently while preserving existing behavior for methods like `POST`

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* Added regression coverage for default `init.body` on `GET`
* Added regression coverage for per-call `init.body` on `HEAD`
* Confirmed `POST` still prefers the per-call `init.body` when no `methodParam.body` is provided

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
