### PR TITLE
refactor(client): Widen proxy apply value type

### DIFF
--- a/packages/rpc4next/src/rpc/client/rpc.ts
+++ b/packages/rpc4next/src/rpc/client/rpc.ts
@@ -19,8 +19,12 @@ const createProxy = <T>(
 
   const proxy = new Proxy(target, {
     // Calling the proxy supplies a value for the most recent dynamic segment.
-    apply(_t, _thisArg, argArray: unknown[]) {
-      const value = argArray[0] as string | number | undefined;
+    apply(
+      _t,
+      _thisArg,
+      argArray: [value?: string | number | string[] | undefined, ...unknown[]],
+    ) {
+      const value = argArray[0];
       const lastPath = paths[paths.length - 1];
       const lastKey = dynamicKeys[dynamicKeys.length - 1];
 


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Broadened the client proxy apply argument type so dynamic segment values can be inferred from the first argument without a narrow cast

## 🧐 Motivation and Background

* The proxy call path now accepts a wider first-argument shape, including string arrays, so the typing should reflect actual supported dynamic segment inputs more accurately

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [x] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* This change is type-focused and does not change the surrounding proxy resolution flow

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
