### PR TITLE
refactor(server): Extract route definition assembly

### DIFF
--- a/packages/rpc4next/src/rpc/server/next-route.ts
+++ b/packages/rpc4next/src/rpc/server/next-route.ts
@@ -797,19 +797,27 @@ export const nextRoute = <
     }
   };
 
-  return attachProcedureDefinition(routeHandler, {
-    ...(options.method
-      ? withProcedureMethod(procedure.definition, options.method)
-      : procedure.definition),
-    ...(options.validateOutput &&
-    procedure.definition.output !== undefined &&
-    outputSchema !== undefined
-      ? {
-          output: {
-            ...procedure.definition.output,
-            runtime: true,
-          },
-        }
-      : {}),
-  }) as NextRouteHandler<TProcedure, TMethod, TValidateOutput, TOnError>;
+  const definitionWithMethod = options.method
+    ? withProcedureMethod(procedure.definition, options.method)
+    : procedure.definition;
+
+  const shouldEnableRuntimeOutputValidation =
+    options.validateOutput &&
+    definitionWithMethod.output !== undefined &&
+    outputSchema !== undefined;
+
+  const routeDefinition = shouldEnableRuntimeOutputValidation
+    ? {
+        ...definitionWithMethod,
+        output: {
+          ...definitionWithMethod.output,
+          runtime: true,
+        },
+      }
+    : definitionWithMethod;
+
+  return attachProcedureDefinition(
+    routeHandler,
+    routeDefinition,
+  ) as NextRouteHandler<TProcedure, TMethod, TValidateOutput, TOnError>;
 };


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Refactored the final procedure-definition assembly in `nextRoute()`
* Introduced intermediate variables for method-aware definitions and runtime output-validation conditions
* Preserved existing behavior while making the output-validation path easier to read

## 🧐 Motivation and Background

* The previous implementation built the final route definition inline inside `attachProcedureDefinition(...)`
* Splitting the logic into named variables makes the control flow clearer, especially around when runtime output validation is enabled
* This improves maintainability without changing the external behavior of `nextRoute()`

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [x] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* No UI changes
* Behavior is unchanged; this is a readability and maintainability refactor
* Runtime output validation is still enabled only when `validateOutput` is true and both the procedure output definition and runtime schema are available

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
