### PR TITLE
fix(cli): Normalize route contract pathnames

### DIFF
--- a/integration/next-app/app/patterns/%5Fescaped/route-contract.ts
+++ b/integration/next-app/app/patterns/%5Fescaped/route-contract.ts
@@ -1,9 +1,9 @@
 import type { ProcedureRouteContract } from "rpc4next/server";
 
 export type Params = {};
-export type RouteContract = ProcedureRouteContract<"/patterns/%5Fescaped", Params>;
+export type RouteContract = ProcedureRouteContract<"/patterns/_escaped", Params>;
 
 export const routeContract = {
-  pathname: "/patterns/%5Fescaped",
+  pathname: "/patterns/_escaped",
   params: {} as Params,
 } as RouteContract;

--- a/integration/next-app/src/folder-patterns.test.ts
+++ b/integration/next-app/src/folder-patterns.test.ts
@@ -9,6 +9,14 @@ const workspaceRoot = path.resolve(
 );
 const generatedRpcPath = path.join(workspaceRoot, "src/generated/rpc.ts");
 const generatedRpc = fs.readFileSync(generatedRpcPath, "utf8");
+const escapedRouteContract = fs.readFileSync(
+  path.join(workspaceRoot, "app/patterns/%5Fescaped/route-contract.ts"),
+  "utf8",
+);
+const malformedRouteContract = fs.readFileSync(
+  path.join(workspaceRoot, "app/patterns/%E3%81%ZZ/route-contract.ts"),
+  "utf8",
+);
 
 const fixturePaths = [
   "app/patterns/dynamic/[category]/page.tsx",
@@ -43,6 +51,11 @@ describe("integration next-app folder pattern coverage", () => {
 
   it("preserves malformed encoded folder keys in PathStructure", () => {
     expect(generatedRpc.includes('"%E3%81%ZZ"')).toBe(true);
+  });
+
+  it("normalizes generated route contract pathnames with the client pathname rules", () => {
+    expect(escapedRouteContract.includes('"/patterns/_escaped"')).toBe(true);
+    expect(malformedRouteContract.includes('"/patterns/%E3%81%ZZ"')).toBe(true);
   });
 
   it("excludes intercepting route variants from PathStructure", () => {

--- a/packages/rpc4next-cli/src/cli/core/route-scanner.test.ts
+++ b/packages/rpc4next-cli/src/cli/core/route-scanner.test.ts
@@ -683,6 +683,28 @@ describe("route-scanner", () => {
 }`);
     });
 
+    it("should decode valid static segments for canonical route contract pathnames", () => {
+      setupTree({
+        testApp: {
+          patterns: {
+            "%5Fescaped": {
+              "page.tsx": "export function Escaped() {};",
+            },
+          },
+        },
+      });
+
+      const { paramsTypes } = scanAppDir(tmpPath("output"), tmpPath("testApp"));
+
+      expect(paramsTypes).toStrictEqual([
+        {
+          paramsType: "{}",
+          dirPath: tmpPosixPath("testApp", "patterns", "%5Fescaped"),
+          pathname: "/patterns/_escaped",
+        },
+      ]);
+    });
+
     it("should keep the original segment name when decodeURIComponent fails", () => {
       setupTree({
         testApp: {
@@ -703,6 +725,28 @@ describe("route-scanner", () => {
     "%E0%A4%A": RpcEndpoint
   }
 }`);
+    });
+
+    it("should keep malformed encoded static segments in canonical route contract pathnames", () => {
+      setupTree({
+        testApp: {
+          patterns: {
+            "%E0%A4%A": {
+              "page.tsx": "export function BrokenEncoding() {};",
+            },
+          },
+        },
+      });
+
+      const { paramsTypes } = scanAppDir(tmpPath("output"), tmpPath("testApp"));
+
+      expect(paramsTypes).toStrictEqual([
+        {
+          paramsType: "{}",
+          dirPath: tmpPosixPath("testApp", "patterns", "%E0%A4%A"),
+          pathname: "/patterns/%E0%A4%A",
+        },
+      ]);
     });
 
     it("should skip private directories even if cached as targetable and keep intercepting routes out of path structure", () => {

--- a/packages/rpc4next-cli/src/cli/core/route-scanner.ts
+++ b/packages/rpc4next-cli/src/cli/core/route-scanner.ts
@@ -95,14 +95,18 @@ const stripInterceptingSegmentPrefix = (entryName: string): string => {
   }
 };
 
-const decodeStaticSegment = (entryName: string): string => {
+const safeDecodeSegment = (entryName: string): string => {
   try {
-    const decoded = decodeURIComponent(entryName);
-
-    return decoded.startsWith("_") ? entryName : decoded;
+    return decodeURIComponent(entryName);
   } catch {
     return entryName;
   }
+};
+
+const getStaticSegmentKey = (entryName: string): string => {
+  const decoded = safeDecodeSegment(entryName);
+
+  return decoded.startsWith("_") ? entryName : decoded;
 };
 
 const getDirectoryMeta = (entryName: string) => {
@@ -121,7 +125,7 @@ const getDirectoryMeta = (entryName: string) => {
     segmentName.endsWith("]");
   const isDynamic = segmentName.startsWith("[") && segmentName.endsWith("]");
   const isPrivate = !isIntercept && segmentName.startsWith("_");
-  const staticKeyName = decodeStaticSegment(segmentName);
+  const staticKeyName = getStaticSegmentKey(segmentName);
 
   return {
     isCatchAll,
@@ -279,7 +283,11 @@ const toRoutePathname = (baseDir: string, fullPath: string): string => {
         return null;
       }
 
-      return meta.segmentName;
+      if (meta.isDynamic || meta.isCatchAll || meta.isOptionalCatchAll) {
+        return meta.segmentName;
+      }
+
+      return safeDecodeSegment(meta.segmentName);
     })
     .filter((segment): segment is string => segment !== null);
 


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Normalized generated route contract pathnames using the same client pathname rules for static segments.
* Valid percent-encoded static segments are decoded in canonical route contract pathnames.
* Malformed percent-encoded static segments are preserved when decoding fails.

## 🧐 Motivation and Background

* Route contract pathnames should match the canonical client-facing pathname behavior.
* Previously, generated route contracts could keep encoded static segment names such as `%5Fescaped`, causing a mismatch with the expected pathname `/patterns/_escaped`.
* Malformed encoded segments still need to remain stable and safe by falling back to the original segment name.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [x] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* No screenshots.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [x] Manual verification completed
* Added route scanner coverage for decoded and malformed static segments.
* Added integration coverage for generated route contract pathname normalization.
