### PR TITLE
chore(build): Ignore Playwright reports

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -8,6 +8,7 @@
     "**/bin/**",
     "**/.next/**",
     "**/coverage/**",
+    "**/playwright-report/**",
     "**/test-results/**"
   ],
   "tabWidth": 2,

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,6 +8,7 @@
     "**/bin/**",
     "**/.next/**",
     "**/coverage/**",
+    "**/playwright-report/**",
     "**/test-results/**"
   ],
   "jsPlugins": ["./oxlint/rpc4next.mjs"],


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Added `**/playwright-report/**` to both oxfmt and oxlint ignore patterns.

## 🧐 Motivation and Background

* Playwright report output is generated during E2E runs and should not be formatted or linted.
* Keeping generated reports ignored avoids unnecessary tool noise and accidental changes.

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [ ] Documentation updated
* [x] Tool configuration updated

## 💡 Notes / Screenshots

* No screenshots needed.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
