### PR TITLE
fix(cli): clear fired debounce timer

### DIFF
--- a/packages/rpc4next-cli/src/cli/debounce.ts
+++ b/packages/rpc4next-cli/src/cli/debounce.ts
@@ -25,6 +25,9 @@ export const debounceOnceRunningWithTrailing = <T extends (...args: any[]) => Pr
     if (timer) clearTimeout(timer);
 
     timer = setTimeout(() => {
+      // Drop the fired timer so its closed-over args can be released.
+      timer = null;
+
       if (isRunning) {
         pendingArgs = args;
 


### PR DESCRIPTION
# Pull Request Template

## Overview

- Fixed a memory retention risk in `debounceOnceRunningWithTrailing`.

## Motivation and Background

- The fired `setTimeout` handle was not reset to `null`.
- Because the timeout callback closes over the latest `args`, the debounced wrapper could keep the last arguments alive longer than necessary while the wrapper itself remains reachable.
- Current watcher usage passes no arguments, but this keeps the generic debounce helper safer for callbacks with arguments.

## Changes

- [ ] Feature added
- [x] Bug fixed
- [ ] Refactored
- [ ] Documentation updated

## Notes / Screenshots

- Added a short code comment explaining that the fired timer is dropped so its closed-over args can be released.
- Existing debounce behavior is unchanged:
  - multiple calls during the delay still execute only the last call
  - calls while execution is running still coalesce into a single trailing run

## Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed

Additional verification:

- `bun run typecheck` passed
