### PR TITLE
fix(cli): Clear scan caches after non-watch generation

### DIFF
--- a/packages/rpc4next-cli/src/cli/cli-handler.test.ts
+++ b/packages/rpc4next-cli/src/cli/cli-handler.test.ts
@@ -47,6 +47,7 @@ describe("handleCli", () => {
       outputPath: expect.stringContaining("/outputDir"),
       paramsFileName: "params.json",
       logger,
+      preserveCache: false,
     });
   });
 
@@ -68,6 +69,13 @@ describe("handleCli", () => {
     callback();
 
     expect(generatorModule.generate).toHaveBeenCalledTimes(1);
+    expect(generatorModule.generate).toHaveBeenCalledWith({
+      baseDir: expect.stringContaining("/testDir"),
+      outputPath: expect.stringContaining("/outputDir"),
+      paramsFileName: "params.json",
+      logger,
+      preserveCache: true,
+    });
   });
 
   it("should work correctly when options are omitted", () => {
@@ -81,6 +89,7 @@ describe("handleCli", () => {
       outputPath: expect.stringContaining("/outputDir"),
       paramsFileName: null,
       logger,
+      preserveCache: false,
     });
     expect(watcherModule.setupWatcher).not.toHaveBeenCalled();
     expect(logger.error).not.toHaveBeenCalled();

--- a/packages/rpc4next-cli/src/cli/cli-handler.ts
+++ b/packages/rpc4next-cli/src/cli/cli-handler.ts
@@ -11,6 +11,7 @@ const handleGenerateSafely = (
   outputPath: string,
   paramsFileName: string | null,
   logger: Logger,
+  preserveCache = false,
 ): ExitCode => {
   try {
     generate({
@@ -18,6 +19,7 @@ const handleGenerateSafely = (
       outputPath,
       paramsFileName,
       logger,
+      preserveCache,
     });
 
     return EXIT_SUCCESS;
@@ -53,7 +55,8 @@ export const handleCli = (
     setupWatcher(
       resolvedBaseDir,
       () => {
-        handleGenerateSafely(resolvedBaseDir, resolvedOutputPath, paramsFileName, logger);
+        // Watch mode keeps scan caches warm and invalidates changed paths in the watcher.
+        handleGenerateSafely(resolvedBaseDir, resolvedOutputPath, paramsFileName, logger, true);
       },
       logger,
     );

--- a/packages/rpc4next-cli/src/cli/core/cache.test.ts
+++ b/packages/rpc4next-cli/src/cli/core/cache.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
+  clearScanCaches,
   clearScanAppDirCacheAbove,
   clearVisitedDirsCacheAbove,
   createScanAppDirCacheKey,
@@ -82,6 +83,31 @@ describe("clearVisitedDirsCacheAbove", () => {
     const originalSize = visitedDirsCache.size;
     clearVisitedDirsCacheAbove(filePath);
     expect(visitedDirsCache.size).toBe(originalSize);
+  });
+});
+
+describe("clearScanCaches", () => {
+  it("removes all scan caches", () => {
+    visitedDirsCache.set("/project", true);
+    scanAppDirCache.set(
+      createScanAppDirCacheKey({
+        output: "/output",
+        input: "/project",
+        indent: "",
+        rootDir: "/project",
+        parentParams: [],
+      }),
+      {
+        pathStructure: "",
+        imports: [],
+        paramsTypes: [],
+      },
+    );
+
+    clearScanCaches();
+
+    expect(visitedDirsCache.size).toBe(0);
+    expect(scanAppDirCache.size).toBe(0);
   });
 });
 

--- a/packages/rpc4next-cli/src/cli/core/cache.ts
+++ b/packages/rpc4next-cli/src/cli/core/cache.ts
@@ -52,3 +52,9 @@ export const clearVisitedDirsCacheAbove = (targetPath: string): void => {
 export const clearScanAppDirCacheAbove = (targetPath: string): void => {
   clearCacheAbove(scanAppDirCache, targetPath);
 };
+
+// Drop strong references held by module-scoped scan caches after non-watch generation.
+export const clearScanCaches = (): void => {
+  visitedDirsCache.clear();
+  scanAppDirCache.clear();
+};

--- a/packages/rpc4next-cli/src/cli/generator.test.ts
+++ b/packages/rpc4next-cli/src/cli/generator.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { cleanupTempDir, makeTempDir, writeTree } from "../test-helpers/tmp-dir.js";
 import { SUCCESS_INDENT_LEVEL, SUCCESS_PAD_LENGTH, SUCCESS_SEPARATOR } from "./constants.js";
+import { scanAppDirCache, visitedDirsCache } from "./core/cache.js";
 import * as generatePathStructure from "./core/generate-path-structure.js";
 import { ROUTE_CONTRACT_GENERATED_MARKER } from "./core/generate-path-structure.js";
 import { generate } from "./generator.js";
@@ -23,6 +24,86 @@ describe("generate", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
+    scanAppDirCache.clear();
+    visitedDirsCache.clear();
+  });
+
+  it("clears scan caches after non-watch generation", () => {
+    vi.spyOn(generatePathStructure, "generatePathStructure").mockReturnValue({
+      pathStructure: "generated-type-content",
+      paramsTypes: [],
+    });
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+
+    visitedDirsCache.set("/cached/app", true);
+    scanAppDirCache.set("cached-scan", {
+      pathStructure: "cached",
+      imports: [],
+      paramsTypes: [],
+    });
+
+    generate({
+      baseDir,
+      outputPath,
+      paramsFileName: null,
+      logger,
+    });
+
+    expect(visitedDirsCache.size).toBe(0);
+    expect(scanAppDirCache.size).toBe(0);
+  });
+
+  it("preserves scan caches during watch generation", () => {
+    vi.spyOn(generatePathStructure, "generatePathStructure").mockReturnValue({
+      pathStructure: "generated-type-content",
+      paramsTypes: [],
+    });
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+
+    visitedDirsCache.set("/cached/app", true);
+    scanAppDirCache.set("cached-scan", {
+      pathStructure: "cached",
+      imports: [],
+      paramsTypes: [],
+    });
+
+    generate({
+      baseDir,
+      outputPath,
+      paramsFileName: null,
+      logger,
+      preserveCache: true,
+    });
+
+    expect(visitedDirsCache.size).toBe(1);
+    expect(scanAppDirCache.size).toBe(1);
+  });
+
+  it("clears scan caches when non-watch generation throws", () => {
+    vi.spyOn(generatePathStructure, "generatePathStructure").mockImplementation(() => {
+      throw new Error("scan failed");
+    });
+
+    visitedDirsCache.set("/cached/app", true);
+    scanAppDirCache.set("cached-scan", {
+      pathStructure: "cached",
+      imports: [],
+      paramsTypes: [],
+    });
+
+    expect(() =>
+      generate({
+        baseDir,
+        outputPath,
+        paramsFileName: null,
+        logger,
+      }),
+    ).toThrow("scan failed");
+
+    expect(visitedDirsCache.size).toBe(0);
+    expect(scanAppDirCache.size).toBe(0);
   });
 
   it("writes the output file when it does not exist", () => {

--- a/packages/rpc4next-cli/src/cli/generator.ts
+++ b/packages/rpc4next-cli/src/cli/generator.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { SUCCESS_INDENT_LEVEL, SUCCESS_PAD_LENGTH, SUCCESS_SEPARATOR } from "./constants.js";
+import { clearScanCaches } from "./core/cache.js";
 import {
   generatePathStructure,
   ROUTE_CONTRACT_GENERATED_MARKER,
@@ -94,71 +95,80 @@ export const generate = ({
   outputPath,
   paramsFileName,
   logger,
+  preserveCache = false,
 }: {
   baseDir: string;
   outputPath: string;
   paramsFileName: string | null;
   logger: Logger;
+  preserveCache?: boolean;
 }) => {
-  logger.info("Generating types...", { event: "generate" });
+  try {
+    logger.info("Generating types...", { event: "generate" });
 
-  const { pathStructure, paramsTypes } = generatePathStructure(outputPath, baseDir);
+    const { pathStructure, paramsTypes } = generatePathStructure(outputPath, baseDir);
 
-  if (writeFileIfChanged(outputPath, pathStructure)) {
-    logger.success(
-      padMessage(
-        "Path structure type",
-        relativeFromRoot(outputPath),
-        SUCCESS_SEPARATOR,
-        SUCCESS_PAD_LENGTH,
-      ),
-      { indentLevel: SUCCESS_INDENT_LEVEL },
-    );
-  } else {
-    logger.info(
-      padMessage(
-        "Unchanged path type",
-        relativeFromRoot(outputPath),
-        SUCCESS_SEPARATOR,
-        SUCCESS_PAD_LENGTH,
-      ),
-      { indentLevel: SUCCESS_INDENT_LEVEL },
-    );
-  }
-
-  if (paramsFileName) {
-    let wroteParamsFile = false;
-    const expectedFilePaths = new Set(
-      paramsTypes.map(({ dirPath }) => path.resolve(path.join(dirPath, paramsFileName))),
-    );
-
-    paramsTypes.forEach(({ paramsType, dirPath }) => {
-      const filePath = path.join(dirPath, paramsFileName);
-      const didWrite = writeFileIfChanged(filePath, paramsType);
-
-      wroteParamsFile = wroteParamsFile || didWrite;
-    });
-
-    cleanupStaleGeneratedParamsFiles({
-      baseDir,
-      paramsFileName,
-      expectedFilePaths,
-    });
-
-    if (wroteParamsFile) {
+    if (writeFileIfChanged(outputPath, pathStructure)) {
       logger.success(
-        padMessage("Params types", paramsFileName, SUCCESS_SEPARATOR, SUCCESS_PAD_LENGTH),
-        {
-          indentLevel: SUCCESS_INDENT_LEVEL,
-        },
+        padMessage(
+          "Path structure type",
+          relativeFromRoot(outputPath),
+          SUCCESS_SEPARATOR,
+          SUCCESS_PAD_LENGTH,
+        ),
+        { indentLevel: SUCCESS_INDENT_LEVEL },
       );
     } else {
       logger.info(
-        padMessage("Unchanged params", paramsFileName, SUCCESS_SEPARATOR, SUCCESS_PAD_LENGTH),
-        {
-          indentLevel: SUCCESS_INDENT_LEVEL,
-        },
+        padMessage(
+          "Unchanged path type",
+          relativeFromRoot(outputPath),
+          SUCCESS_SEPARATOR,
+          SUCCESS_PAD_LENGTH,
+        ),
+        { indentLevel: SUCCESS_INDENT_LEVEL },
       );
+    }
+
+    if (paramsFileName) {
+      let wroteParamsFile = false;
+      const expectedFilePaths = new Set(
+        paramsTypes.map(({ dirPath }) => path.resolve(path.join(dirPath, paramsFileName))),
+      );
+
+      paramsTypes.forEach(({ paramsType, dirPath }) => {
+        const filePath = path.join(dirPath, paramsFileName);
+        const didWrite = writeFileIfChanged(filePath, paramsType);
+
+        wroteParamsFile = wroteParamsFile || didWrite;
+      });
+
+      cleanupStaleGeneratedParamsFiles({
+        baseDir,
+        paramsFileName,
+        expectedFilePaths,
+      });
+
+      if (wroteParamsFile) {
+        logger.success(
+          padMessage("Params types", paramsFileName, SUCCESS_SEPARATOR, SUCCESS_PAD_LENGTH),
+          {
+            indentLevel: SUCCESS_INDENT_LEVEL,
+          },
+        );
+      } else {
+        logger.info(
+          padMessage("Unchanged params", paramsFileName, SUCCESS_SEPARATOR, SUCCESS_PAD_LENGTH),
+          {
+            indentLevel: SUCCESS_INDENT_LEVEL,
+          },
+        );
+      }
+    }
+  } finally {
+    if (!preserveCache) {
+      // Normal generation should not retain scan results between embedded calls.
+      clearScanCaches();
     }
   }
 };


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Clear CLI scan caches after normal generation while preserving them during watch mode.

## 🧐 Motivation and Background

* Non-watch generation should not keep module-scoped scan cache references between embedded calls.
* Watch mode still benefits from warm caches and relies on watcher invalidation for changed paths.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* Added `preserveCache` handling so watch generation keeps caches warm.
* Added `clearScanCaches()` to clear both visited directory and app directory scan caches.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
* Added tests for non-watch cache clearing, watch cache preservation, and cleanup on generation errors.
