### PR TITLE
fix(cli): Clear scan caches on watcher close

### DIFF
--- a/packages/rpc4next-cli/src/cli/watcher.test.ts
+++ b/packages/rpc4next-cli/src/cli/watcher.test.ts
@@ -10,6 +10,7 @@ vi.mock("./core/cache.js", () => ({
   clearCntCache: vi.fn<(...args: unknown[]) => unknown>(),
   clearVisitedDirsCacheAbove: vi.fn<(...args: unknown[]) => unknown>(),
   clearScanAppDirCacheAbove: vi.fn<(...args: unknown[]) => unknown>(),
+  clearScanCaches: vi.fn<(...args: unknown[]) => unknown>(),
 }));
 
 vi.spyOn(debounceModule, "debounceOnceRunningWithTrailing").mockImplementation((fn) => fn);
@@ -216,6 +217,7 @@ describe("setupWatcher", () => {
     await signalHandlers.get("SIGINT")?.values().next().value?.();
 
     expect(mockClose).toHaveBeenCalled();
+    expect(cacheModule.clearScanCaches).toHaveBeenCalledTimes(1);
     expect(signalHandlers.get("SIGINT")?.size).toBe(0);
     expect(signalHandlers.get("SIGTERM")?.size).toBe(0);
     expect(logger.info).toHaveBeenCalledWith("Watcher closed.", {
@@ -241,6 +243,7 @@ describe("setupWatcher", () => {
     await flushPromises();
 
     expect(mockCloseError).toHaveBeenCalled();
+    expect(cacheModule.clearScanCaches).toHaveBeenCalledTimes(2);
     expect(signalHandlers.get("SIGINT")?.size).toBe(0);
     expect(signalHandlers.get("SIGTERM")?.size).toBe(0);
     expect(logger.error).toHaveBeenCalledWith("Failed to close watcher: close fail");
@@ -264,6 +267,7 @@ describe("setupWatcher", () => {
     await dispose();
 
     expect(mockClose).toHaveBeenCalledTimes(1);
+    expect(cacheModule.clearScanCaches).toHaveBeenCalledTimes(1);
     expect(signalHandlers.get("SIGINT")?.size).toBe(0);
     expect(signalHandlers.get("SIGTERM")?.size).toBe(0);
   });

--- a/packages/rpc4next-cli/src/cli/watcher.ts
+++ b/packages/rpc4next-cli/src/cli/watcher.ts
@@ -1,7 +1,11 @@
 import chokidar from "chokidar";
 
 import { END_POINT_FILE_NAMES } from "./constants.js";
-import { clearScanAppDirCacheAbove, clearVisitedDirsCacheAbove } from "./core/cache.js";
+import {
+  clearScanAppDirCacheAbove,
+  clearScanCaches,
+  clearVisitedDirsCacheAbove,
+} from "./core/cache.js";
 import { relativeFromRoot } from "./core/path-utils.js";
 import { debounceOnceRunningWithTrailing } from "./debounce.js";
 import type { Logger } from "./types.js";
@@ -75,14 +79,17 @@ export const setupWatcher = (
     process.off("SIGINT", cleanup);
     process.off("SIGTERM", cleanup);
 
-    closePromise ??= watcher
-      .close()
-      .then(() => {
-        logger.info("Watcher closed.", { event: "watch" });
-      })
-      .catch((err) => {
-        logger.error(`Failed to close watcher: ${err.message}`);
-      });
+    if (!closePromise) {
+      clearScanCaches();
+      closePromise = watcher
+        .close()
+        .then(() => {
+          logger.info("Watcher closed.", { event: "watch" });
+        })
+        .catch((err) => {
+          logger.error(`Failed to close watcher: ${err.message}`);
+        });
+    }
 
     return closePromise;
   };


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Clears all scan caches when the watcher is disposed or closed by a termination signal.
* Adds watcher tests to verify scan cache cleanup happens during normal close, close failure, and manual disposal.

## 🧐 Motivation and Background

* Watch mode should not leave stale scan cache state behind after shutdown.
* Cleanup should run only once even when close handling is triggered multiple times.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* No screenshots.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [x] Manual verification completed
