### PR TITLE
fix(cli): Cancel debounced generate on cleanup

### DIFF
--- a/packages/rpc4next-cli/src/cli/debounce.test.ts
+++ b/packages/rpc4next-cli/src/cli/debounce.test.ts
@@ -85,4 +85,49 @@ describe("debounceOnceRunningWithTrailing", () => {
 
     vi.useRealTimers();
   });
+
+  it("should cancel a pending timer and release its arguments", async () => {
+    vi.useFakeTimers();
+    const callback = vi.fn<(value: string) => void>();
+    const debounced = debounceOnceRunningWithTrailing(callback, 500);
+
+    debounced("test");
+    debounced.cancel();
+
+    vi.advanceTimersByTime(500);
+    await vi.runAllTicks();
+
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("should cancel pending trailing arguments while callback is running", async () => {
+    vi.useFakeTimers();
+
+    let finish!: () => void;
+    const callback = vi.fn<(value: string) => Promise<void>>(async () => {
+      await new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+    });
+    const debounced = debounceOnceRunningWithTrailing(callback, 300);
+
+    debounced("A");
+    vi.advanceTimersByTime(300);
+    await vi.runAllTicks();
+
+    debounced("B");
+    vi.advanceTimersByTime(300);
+    await vi.runAllTicks();
+
+    debounced.cancel();
+    finish();
+    await vi.runAllTicks();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith("A");
+
+    vi.useRealTimers();
+  });
 });

--- a/packages/rpc4next-cli/src/cli/debounce.ts
+++ b/packages/rpc4next-cli/src/cli/debounce.ts
@@ -1,7 +1,13 @@
+type CancellableDebounced<T extends (...args: any[]) => Promise<void> | void> = ((
+  ...args: Parameters<T>
+) => void) & {
+  cancel: () => void;
+};
+
 export const debounceOnceRunningWithTrailing = <T extends (...args: any[]) => Promise<void> | void>(
   func: T,
   delay: number,
-) => {
+): CancellableDebounced<T> => {
   let timer: ReturnType<typeof setTimeout> | null = null;
   let isRunning = false;
   let pendingArgs: Parameters<T> | null = null;
@@ -21,7 +27,7 @@ export const debounceOnceRunningWithTrailing = <T extends (...args: any[]) => Pr
     }
   };
 
-  return (...args: Parameters<T>) => {
+  const debounced = (...args: Parameters<T>) => {
     if (timer) clearTimeout(timer);
 
     timer = setTimeout(() => {
@@ -37,4 +43,15 @@ export const debounceOnceRunningWithTrailing = <T extends (...args: any[]) => Pr
       execute(...args);
     }, delay);
   };
+
+  debounced.cancel = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+
+    pendingArgs = null;
+  };
+
+  return debounced;
 };

--- a/packages/rpc4next-cli/src/cli/watcher.test.ts
+++ b/packages/rpc4next-cli/src/cli/watcher.test.ts
@@ -13,7 +13,9 @@ vi.mock("./core/cache.js", () => ({
   clearScanCaches: vi.fn<(...args: unknown[]) => unknown>(),
 }));
 
-vi.spyOn(debounceModule, "debounceOnceRunningWithTrailing").mockImplementation((fn) => fn);
+const debounceSpy = vi
+  .spyOn(debounceModule, "debounceOnceRunningWithTrailing")
+  .mockImplementation((fn) => Object.assign(fn, { cancel: vi.fn<() => void>() }));
 
 type WatchAllHandler = (event: string, path: string) => void;
 type WatchErrorHandler = (error: unknown) => void;
@@ -270,6 +272,63 @@ describe("setupWatcher", () => {
     expect(cacheModule.clearScanCaches).toHaveBeenCalledTimes(1);
     expect(signalHandlers.get("SIGINT")?.size).toBe(0);
     expect(signalHandlers.get("SIGTERM")?.size).toBe(0);
+  });
+
+  it.each([
+    ["dispose", async (dispose: () => Promise<void>) => dispose()],
+    [
+      "SIGINT",
+      async () => {
+        await signalHandlers.get("SIGINT")?.values().next().value?.();
+      },
+    ],
+    [
+      "SIGTERM",
+      async () => {
+        await signalHandlers.get("SIGTERM")?.values().next().value?.();
+      },
+    ],
+  ])("should not run scheduled generate after %s cleanup", async (_, cleanup) => {
+    vi.useFakeTimers();
+
+    const cancel = vi.fn<() => void>();
+    debounceSpy.mockImplementationOnce((fn, delay) => {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const debounced = Object.assign(
+        () => {
+          if (timer) clearTimeout(timer);
+          timer = setTimeout(fn, delay);
+        },
+        {
+          cancel: () => {
+            cancel();
+            if (timer) {
+              clearTimeout(timer);
+              timer = null;
+            }
+          },
+        },
+      );
+
+      return debounced;
+    });
+
+    const dispose = setupWatcher("/base/dir", onGenerate, logger);
+
+    const readyHandler = fakeOn.mock.calls.find(
+      (call: [string, WatchHandler]) => call[0] === "ready",
+    )?.[1] as WatchReadyHandler | undefined;
+
+    readyHandler?.();
+    await cleanup(dispose);
+
+    vi.advanceTimersByTime(300);
+    await vi.runAllTicks();
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(onGenerate).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
   });
 
   it("should correctly ignore non-target files and include target files", () => {

--- a/packages/rpc4next-cli/src/cli/watcher.ts
+++ b/packages/rpc4next-cli/src/cli/watcher.ts
@@ -80,6 +80,7 @@ export const setupWatcher = (
     process.off("SIGTERM", cleanup);
 
     if (!closePromise) {
+      debouncedGenerate.cancel();
       clearScanCaches();
       closePromise = watcher
         .close()


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Added cancellation support to `debounceOnceRunningWithTrailing`.
* Cancel pending debounced generation when watcher cleanup runs.
* Added tests to verify pending timers and trailing arguments are cancelled correctly.

## 🧐 Motivation and Background

* Watcher cleanup could leave a scheduled debounced generate callback pending after disposal or signal-based shutdown.
* Cancelling the debounced callback during cleanup prevents generation from running after the watcher has been closed and caches have been cleared.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [x] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* No screenshots needed.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [x] Manual verification completed
