### PR TITLE
refactor(package): Remove internal lib exports

### DIFF
--- a/packages/rpc4next/package.json
+++ b/packages/rpc4next/package.json
@@ -51,26 +51,6 @@
         "types": "./dist/rpc/server/index.d.ts",
         "default": "./dist/rpc/server/index.js"
       }
-    },
-    "./lib/constants": {
-      "import": {
-        "types": "./dist/rpc/lib/constants.d.ts",
-        "default": "./dist/rpc/lib/constants.js"
-      },
-      "default": {
-        "types": "./dist/rpc/lib/constants.d.ts",
-        "default": "./dist/rpc/lib/constants.js"
-      }
-    },
-    "./lib/types": {
-      "import": {
-        "types": "./dist/rpc/lib/types.d.ts",
-        "default": "./dist/rpc/lib/types.js"
-      },
-      "default": {
-        "types": "./dist/rpc/lib/types.d.ts",
-        "default": "./dist/rpc/lib/types.js"
-      }
     }
   },
   "publishConfig": {


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Removed the `./lib/constants` and `./lib/types` subpath exports from `packages/rpc4next/package.json`.

## 🧐 Motivation and Background

* These internal `lib` entry points should not be exposed as public package exports.
* Keeping the export map focused on supported public entry points helps prevent consumers from depending on internal implementation details.

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [x] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* No screenshots applicable.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
