### PR TITLE
fix(cli): Contain debounce callback rejections

### DIFF
--- a/packages/rpc4next-cli/src/cli/debounce.test.ts
+++ b/packages/rpc4next-cli/src/cli/debounce.test.ts
@@ -2,6 +2,22 @@ import { describe, expect, it, vi } from "vitest";
 
 import { debounceOnceRunningWithTrailing } from "./debounce.js";
 
+const collectUnhandledRejections = () => {
+  const rejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    rejections.push(reason);
+  };
+
+  process.on("unhandledRejection", onUnhandledRejection);
+
+  return {
+    rejections,
+    stop: () => {
+      process.off("unhandledRejection", onUnhandledRejection);
+    },
+  };
+};
+
 describe("debounceOnceRunningWithTrailing", () => {
   it("should call the callback after the specified delay", async () => {
     vi.useFakeTimers();
@@ -129,5 +145,105 @@ describe("debounceOnceRunningWithTrailing", () => {
     expect(callback).toHaveBeenCalledWith("A");
 
     vi.useRealTimers();
+  });
+
+  it("should not create an unhandled rejection when the callback rejects", async () => {
+    vi.useFakeTimers();
+    const unhandled = collectUnhandledRejections();
+    const callback = vi.fn<(value: string) => Promise<void>>().mockRejectedValue(new Error("fail"));
+    const debounced = debounceOnceRunningWithTrailing(callback, 100);
+
+    try {
+      debounced("A");
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.runAllTicks();
+      await Promise.resolve();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(unhandled.rejections).toEqual([]);
+    } finally {
+      unhandled.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it("should run the next debounced call after a rejection", async () => {
+    vi.useFakeTimers();
+    const unhandled = collectUnhandledRejections();
+    let callCount = 0;
+    const callback = vi.fn<(value: string) => Promise<void>>(async () => {
+      callCount += 1;
+
+      if (callCount === 1) {
+        throw new Error("fail");
+      }
+    });
+    const debounced = debounceOnceRunningWithTrailing(callback, 100);
+
+    try {
+      debounced("A");
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.runAllTicks();
+
+      debounced("B");
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.runAllTicks();
+      await Promise.resolve();
+
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback.mock.calls[0][0]).toBe("A");
+      expect(callback.mock.calls[1][0]).toBe("B");
+      expect(unhandled.rejections).toEqual([]);
+    } finally {
+      unhandled.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it("should keep state consistent when a trailing callback rejects", async () => {
+    vi.useFakeTimers();
+    const unhandled = collectUnhandledRejections();
+    let finishFirst!: () => void;
+    const callback = vi.fn<(value: string) => Promise<void>>(async (value) => {
+      if (value === "A") {
+        await new Promise<void>((resolve) => {
+          finishFirst = resolve;
+        });
+      }
+
+      if (value === "C") {
+        throw new Error("trailing fail");
+      }
+    });
+    const debounced = debounceOnceRunningWithTrailing(callback, 100);
+
+    try {
+      debounced("A");
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.runAllTicks();
+
+      debounced("B");
+      debounced("C");
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.runAllTicks();
+
+      finishFirst();
+      await vi.runAllTicks();
+      await Promise.resolve();
+
+      debounced("D");
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.runAllTicks();
+      await Promise.resolve();
+
+      expect(callback).toHaveBeenCalledTimes(3);
+      expect(callback.mock.calls[0][0]).toBe("A");
+      expect(callback.mock.calls[1][0]).toBe("C");
+      expect(callback.mock.calls[2][0]).toBe("D");
+      expect(unhandled.rejections).toEqual([]);
+    } finally {
+      unhandled.stop();
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/rpc4next-cli/src/cli/debounce.ts
+++ b/packages/rpc4next-cli/src/cli/debounce.ts
@@ -16,6 +16,8 @@ export const debounceOnceRunningWithTrailing = <T extends (...args: any[]) => Pr
     isRunning = true;
     try {
       await func(...args);
+    } catch {
+      // Debounced calls do not expose a promise, so contain async failures here.
     } finally {
       isRunning = false;
 


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Contained rejected async callbacks inside `debounceOnceRunningWithTrailing` so debounced calls do not create unhandled promise rejections.
* Added regression tests for rejected callbacks, subsequent debounced calls after rejection, and rejected trailing callbacks.

## 🧐 Motivation and Background

* Debounced calls do not expose a promise to callers, so async callback failures need to be handled internally.
* Without this, rejected callbacks could surface as unhandled rejections and leave debounce state behavior less well-covered.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* No screenshots applicable.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [x] Manual verification completed
