### PR TITLE
fix(cli): Detect typed route exports

### DIFF
--- a/packages/rpc4next-cli/src/cli/core/scan-utils.test.ts
+++ b/packages/rpc4next-cli/src/cli/core/scan-utils.test.ts
@@ -105,6 +105,30 @@ describe("scanEndpointFile", () => {
     expect(result.routes[0]?.type).toBe('{ "$patch": typeof PATCH_2fb9d0ae6e8b8cfc }');
   });
 
+  it("should return a route definition for a type annotated constant function", () => {
+    const { inputFile, outputFile, rootDir } = createPaths();
+    writeTree(rootDir, {
+      "input.ts": "export const GET: RouteHandler = () => ({ data: 'test' });",
+    });
+
+    const result = scanEndpointFile(outputFile, inputFile);
+    expect(result.routes).toHaveLength(1);
+    expect(result.routes[0]?.importName).toBe("GET_84a33c1aab9019d2");
+    expect(result.routes[0]?.type).toBe('{ "$get": typeof GET_84a33c1aab9019d2 }');
+  });
+
+  it("should return a route definition for a function type annotated constant", () => {
+    const { inputFile, outputFile, rootDir } = createPaths();
+    writeTree(rootDir, {
+      "input.ts": "export const POST: (request: Request) => Response = () => new Response();",
+    });
+
+    const result = scanEndpointFile(outputFile, inputFile);
+    expect(result.routes).toHaveLength(1);
+    expect(result.routes[0]?.importName).toBe("POST_8393a35405bb7d7f");
+    expect(result.routes[0]?.type).toBe('{ "$post": typeof POST_8393a35405bb7d7f }');
+  });
+
   it("should return a route definition for a destructured export", () => {
     const { inputFile, outputFile, rootDir } = createPaths();
     writeTree(rootDir, {
@@ -129,6 +153,18 @@ describe("scanEndpointFile", () => {
     expect(result.routes[0]?.type).toBe('{ "$delete": typeof DELETE_bacf7eb8c865f8b9 }');
   });
 
+  it("should return a route definition for an exported binding list", () => {
+    const { inputFile, outputFile, rootDir } = createPaths();
+    writeTree(rootDir, {
+      "input.ts": "const GET = () => ({ data: 'test' }); export { GET };",
+    });
+
+    const result = scanEndpointFile(outputFile, inputFile);
+    expect(result.routes).toHaveLength(1);
+    expect(result.routes[0]?.importName).toBe("GET_84a33c1aab9019d2");
+    expect(result.routes[0]?.type).toBe('{ "$get": typeof GET_84a33c1aab9019d2 }');
+  });
+
   it("should return stable aliases for multiple scans of the same route", () => {
     const { inputFile, outputFile, rootDir } = createPaths();
     writeTree(rootDir, {
@@ -147,6 +183,16 @@ describe("scanEndpointFile", () => {
     const { inputFile, outputFile, rootDir } = createPaths();
     writeTree(rootDir, {
       "input.ts": "export function OTHER() { return { data: 'test' }; }",
+    });
+
+    const result = scanEndpointFile(outputFile, inputFile);
+    expect(result.routes).toEqual([]);
+  });
+
+  it("should skip constants whose names only contain an HTTP method", () => {
+    const { inputFile, outputFile, rootDir } = createPaths();
+    writeTree(rootDir, {
+      "input.ts": "export const METHOD_GET = () => ({ data: 'test' });",
     });
 
     const result = scanEndpointFile(outputFile, inputFile);

--- a/packages/rpc4next-cli/src/cli/core/scan-utils.ts
+++ b/packages/rpc4next-cli/src/cli/core/scan-utils.ts
@@ -41,9 +41,15 @@ const findQueryExport = (fileContents: string) => {
 };
 
 const hasRouteExport = (fileContents: string, httpMethod: HttpMethod) => {
-  return new RegExp(
-    `export (async )?(function ${httpMethod} ?\\(|const ${httpMethod} ?=|\\{[^}]*\\b${httpMethod}\\b[^}]*\\} ?=|const \\{[^}]*\\b${httpMethod}\\b[^}]*\\} ?=|\\{[^}]*\\b${httpMethod}\\b[^}]*\\} from)`,
-  ).test(fileContents);
+  const exportPatterns = [
+    `async\\s+function\\s+${httpMethod}\\s*\\(`,
+    `function\\s+${httpMethod}\\s*\\(`,
+    `const\\s+${httpMethod}\\b\\s*(?::(?:[^=]|=>)*?)?=`,
+    `const\\s+\\{[^}]*\\b${httpMethod}\\b[^}]*\\}\\s*=`,
+    `\\{[^}]*\\b${httpMethod}\\b[^}]*\\}(?:\\s+from)?`,
+  ];
+
+  return new RegExp(`export\\s+(?:${exportPatterns.join("|")})`).test(fileContents);
 };
 
 export const scanEndpointFile = (


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Improved route export detection in `scanEndpointFile` to support additional valid endpoint export forms, including type-annotated constant functions and exported binding lists.

## 🧐 Motivation and Background

* Route scanning previously relied on a single broad regular expression, which missed some legitimate route handler declarations such as typed constants and `export { GET }` bindings.
* The detection logic is now split into clearer export patterns so supported route declarations are easier to extend and verify.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [x] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* Added coverage to ensure constants whose names only contain an HTTP method, such as `METHOD_GET`, are not incorrectly treated as route exports.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [x] Manual verification completed
