### PR TITLE
fix(ci): Use client id for renovate app token

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: renovate-app-token
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
           permission-administration: read
           permission-checks: write


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Fixed the Renovate workflow to pass `RENOVATE_APP_ID` using `client-id` for `actions/create-github-app-token`.

## 🧐 Motivation and Background

* `actions/create-github-app-token` v3 expects `client-id`, so using `app-id` could prevent the GitHub App token from being created correctly.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* No screenshots.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
